### PR TITLE
feat: Interpret standard python escapes in the delimiter strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ content to include.
  work correctly in their new location. Default: `true`. Possible values are
  `true` and `false`.
 
+Note that the **start** and **end** strings may contain usual (Python-style)
+escape sequences like `\n`, which is handy if you need to match on a multi-line
+start or end trigger.
+
 ##### Examples
 
 ```

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -54,10 +54,13 @@ def _on_page_markdown(markdown, page, **kwargs):
 
         return text_to_include
 
+    def interpret_escapes(str):
+        return str.encode('latin-1','backslashreplace').decode('unicode_escape')
+
     def found_include_markdown_tag(match):
         filename = match.group('filename')
-        start = match.group('start')
-        end = match.group('end')
+        start = interpret_escapes(match.group('start'))
+        end = interpret_escapes(match.group('end'))
 
         option_value = match.group('rewrite_relative_urls')
         if option_value in [None, 'true']:


### PR DESCRIPTION
  Prior to this change, the only way to include a newline in the start or
  end trigger in the include-markdown directives was to lierally have the
  string span multiple lines. I needed to extract some content from a file
  generated by another tool, and the only reliable markers had multiple
  newlines, making my markdown files look rather awkward every time I had to
  do an include. This commit allows newlines, tabs, etc to be specified
  with standard escapes, which is much easier to read and keeps the
  triggers on a single line in my markdown file.