### PR TITLE
Interpret standard python escapes in delimiter strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ content to include.
  work correctly in their new location. Default: `true`. Possible values are
  `true` and `false`.
 
+Note that the **start** and **end** strings may contain usual (Python-style)
+escape sequences like `\n`, which is handy if you need to match on a multi-line
+start or end trigger.
+
 ##### Examples
 
 ```

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -59,6 +59,11 @@ def _on_page_markdown(markdown, page, **kwargs):
         start = match.group('start')
         end = match.group('end')
 
+        if start is not None:
+            start = process.interpret_escapes(start)
+        if end is not None:
+            end = process.interpret_escapes(end)
+
         option_value = match.group('rewrite_relative_urls')
         if option_value in [None, 'true']:
             # if unspecified, default to true

--- a/mkdocs_include_markdown_plugin/process.py
+++ b/mkdocs_include_markdown_plugin/process.py
@@ -5,6 +5,14 @@ from pathlib import Path
 from urllib.parse import urlparse, urlunparse
 
 
+def interpret_escapes(value: str) -> str:
+    '''
+      Replaces any standard escape sequences in value with their
+      usual meanings as in ordinary python string literals.
+    '''
+    return value.encode('latin-1', 'backslashreplace').decode('unicode_escape')
+
+
 # Markdown regular expressions. Taken from the original Markdown.pl by John
 # Gruber, and modified to work in Python
 

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -89,6 +89,58 @@ This must be included.
 
 <!-- END INCLUDE -->
 ''',
+        ),
+
+        # Escaped special characters
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  start="<!--\\tstart -->"
+  end="<!--\\tend -->"
+%}
+''',
+            '''This must be ignored.
+<!--\tstart -->
+This must be included.
+<!--\tend -->
+This must be ignored also.''',
+            '''# Header
+
+<!-- BEGIN INCLUDE {filepath} &lt;!--\tstart --&gt; &lt;!--\tend --&gt; -->
+
+This must be included.
+
+<!-- END INCLUDE -->
+''',
+        ),
+
+        # Unescaped special characters
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  start="<!--\nstart -->"
+  end="<!--\nend -->"
+%}
+''',
+            '''This must be ignored.
+<!--\nstart -->
+This must be included.
+<!--\nend -->
+This must be ignored also.''',
+            '''# Header
+
+<!-- BEGIN INCLUDE {filepath} &lt;!--
+start --&gt; &lt;!--
+end --&gt; -->
+
+This must be included.
+
+<!-- END INCLUDE -->
+''',
         )
     ),
 )


### PR DESCRIPTION
  Prior to this change, the only way to include a newline in the start or
  end trigger in the include-markdown directives was to lierally have the
  string span multiple lines. I needed to extract some content from a file
  generated by another tool, and the only reliable markers had multiple
  newlines, making my markdown files look rather awkward every time I had to
  do an include. This commit allows newlines, tabs, etc to be specified
  with standard escapes, which is much easier to read and keeps the
  triggers on a single line in my markdown file.

  As compared to the prior version of this commit, a test has been added
  specifically for the escape sequences, all tests pass, and the layout
  requirements of the pre_commit check should be satisfied.