### PR TITLE
Add support to Offset Markdown headings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ content to include.
  include is wrapped by `<!-- BEGIN INCLUDE -->` and `<!-- END INCLUDE -->`
  comments which help to identify that the content has been included. Possible
  values are `true` and `false`.
+- **heading-offset** (0): Increases the Markdown heading depth by this number.
+ Only supports number sign (#) heading syntax.
 
 > Note that the **start** and **end** strings may contain usual (Python-style)
 escape sequences like `\n`, which is handy if you need to match on a multi-line
@@ -73,6 +75,13 @@ start or end trigger.
    end="<!--\n\ttable-end\n-->"
    rewrite_relative_urls=false
    comments=false
+%}
+```
+
+```jinja
+{%
+   include-markdown "docs/includes/header.md"
+   heading-offset=1
 %}
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ content to include.
  comments which help to identify that the content has been included. Possible
  values are `true` and `false`.
 - **heading-offset** (0): Increases the Markdown heading depth by this number.
- Only supports number sign (#) heading syntax.
+ Only supports number sign (#) heading syntax. Max offset of 5.
 
 > Note that the **start** and **end** strings may contain usual (Python-style)
 escape sequences like `\n`, which is handy if you need to match on a multi-line

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -223,12 +223,16 @@ def get_file_content(markdown, abs_src_path):
             text_to_include = new_text_to_include
 
         # heading offset
-        offset = re.search(ARGUMENT_REGEXES['heading-offset'], arguments_string)
-        if offset:
+        offset_match = re.search(
+            ARGUMENT_REGEXES['heading-offset'],
+            arguments_string,
+        )
+        if offset_match:
+            offset = int(offset_match.group(1))
             lines = []
             for line in text_to_include.splitlines(keepends=True):
                 if line.startswith('#'):
-                    lines.append('#' * int(offset.group(1)) + line)
+                    lines.append('#' * offset + line)
                 else:
                     lines.append(line)
             text_to_include = ''.join(lines)

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -51,7 +51,7 @@ ARGUMENT_REGEXES = {
     'comments': re.compile(r'comments=(\w*)'),
     'preserve_includer_indent': re.compile(r'preserve_includer_indent=(\w*)'),
     'dedent': re.compile(r'dedent=(\w*)'),
-    'heading-offset': re.compile(r'heading-offset=(\d+)'),
+    'heading-offset': re.compile(r'heading-offset=([0-5])'),
 }
 
 

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -51,6 +51,7 @@ ARGUMENT_REGEXES = {
     'comments': re.compile(r'comments=(\w*)'),
     'preserve_includer_indent': re.compile(r'preserve_includer_indent=(\w*)'),
     'dedent': re.compile(r'dedent=(\w*)'),
+    'heading-offset': re.compile(r'heading-offset=(\d+)'),
 }
 
 
@@ -220,6 +221,17 @@ def get_file_content(markdown, abs_src_path):
         new_text_to_include = get_file_content(text_to_include, file_path_abs)
         if new_text_to_include != text_to_include:
             text_to_include = new_text_to_include
+
+        # heading offset
+        offset = re.search(ARGUMENT_REGEXES['heading-offset'], arguments_string)
+        if offset:
+            lines = []
+            for line in text_to_include.splitlines(keepends=True):
+                if line.startswith('#'):
+                    lines.append('#' * int(offset.group(1)) + line)
+                else:
+                    lines.append(line)
+            text_to_include = ''.join(lines)
 
         if not bool_options['comments']['value']:
             return text_to_include

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -254,10 +254,10 @@ This must be included.
   heading-offset=1
 %}
 ''',
-    '''# This should be a second level heading.
+            '''# This should be a second level heading.
 
 Example data''',
-    '''# Header
+            '''# Header
 
 <!-- BEGIN INCLUDE {filepath}   -->
 ## This should be a second level heading.
@@ -275,10 +275,10 @@ Example data
   heading-offset=2
 %}
 ''',
-    '''# This should be a third level heading.
+            '''# This should be a third level heading.
 
 Example data''',
-    '''# Header
+            '''# Header
 
 <!-- BEGIN INCLUDE {filepath}   -->
 ### This should be a third level heading.
@@ -295,10 +295,10 @@ Example data
   include-markdown "{filepath}"
 %}
 ''',
-    '''# This should be a first level heading.
+            '''# This should be a first level heading.
 
 Example data''',
-    '''# Header
+            '''# Header
 
 <!-- BEGIN INCLUDE {filepath}   -->
 # This should be a first level heading.
@@ -316,10 +316,10 @@ Example data
   heading-offset=0
 %}
 ''',
-    '''# This should be a first level heading.
+            '''# This should be a first level heading.
 
 Example data''',
-    '''# Header
+            '''# Header
 
 <!-- BEGIN INCLUDE {filepath}   -->
 # This should be a first level heading.
@@ -337,10 +337,10 @@ Example data
   heading-offset=true
 %}
 ''',
-    '''# This should be a first level heading.
+            '''# This should be a first level heading.
 
 Example data''',
-    '''# Header
+            '''# Header
 
 <!-- BEGIN INCLUDE {filepath}   -->
 # This should be a first level heading.
@@ -348,7 +348,7 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
-        )
+        ),
     ),
 )
 def test_include_markdown(

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -244,6 +244,111 @@ This must be included.
         - Baz
 ''',
         ),
+
+        # Markdown heading offset 1
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  heading-offset=1
+%}
+''',
+    '''# This should be a second level heading.
+
+Example data''',
+    '''# Header
+
+<!-- BEGIN INCLUDE {filepath}   -->
+## This should be a second level heading.
+
+Example data
+<!-- END INCLUDE -->
+''',
+        ),
+        # Markdown heading offset 2
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  heading-offset=2
+%}
+''',
+    '''# This should be a third level heading.
+
+Example data''',
+    '''# Header
+
+<!-- BEGIN INCLUDE {filepath}   -->
+### This should be a third level heading.
+
+Example data
+<!-- END INCLUDE -->
+''',
+        ),
+        # Markdown heading no offset
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+%}
+''',
+    '''# This should be a first level heading.
+
+Example data''',
+    '''# Header
+
+<!-- BEGIN INCLUDE {filepath}   -->
+# This should be a first level heading.
+
+Example data
+<!-- END INCLUDE -->
+''',
+        ),
+        # Markdown heading zero offset
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  heading-offset=0
+%}
+''',
+    '''# This should be a first level heading.
+
+Example data''',
+    '''# Header
+
+<!-- BEGIN INCLUDE {filepath}   -->
+# This should be a first level heading.
+
+Example data
+<!-- END INCLUDE -->
+''',
+        ),
+        # Markdown heading offset string
+        (
+            '''# Header
+
+{%
+  include-markdown "{filepath}"
+  heading-offset=true
+%}
+''',
+    '''# This should be a first level heading.
+
+Example data''',
+    '''# Header
+
+<!-- BEGIN INCLUDE {filepath}   -->
+# This should be a first level heading.
+
+Example data
+<!-- END INCLUDE -->
+''',
+        )
     ),
 )
 def test_include_markdown(


### PR DESCRIPTION
Fixes #45

This PR adds a new option for include-markdown to have headings depth from included files to have 1-5 number of levels.  0 is the default offset.

heading-offset=1

Would look like the following:

File to import:
'''# Test Header

Example Test
'''

Rendered:
'''## Test Header

Example Test
'''


