### PR TITLE
Normalize argument names using '-' for words separation

### DIFF
--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -47,9 +47,9 @@ INCLUDE_MARKDOWN_TAG_REGEX = re.compile(
 ARGUMENT_REGEXES = {
     'start': re.compile(r'start="([^"]+)"'),
     'end': re.compile(r'end="([^"]+)"'),
-    'rewrite_relative_urls': re.compile(r'rewrite_relative_urls=(\w*)'),
+    'rewrite-relative-urls': re.compile(r'rewrite-relative-urls=(\w*)'),
     'comments': re.compile(r'comments=(\w*)'),
-    'preserve_includer_indent': re.compile(r'preserve_includer_indent=(\w*)'),
+    'preserve-includer-indent': re.compile(r'preserve-includer-indent=(\w*)'),
     'dedent': re.compile(r'dedent=(\w*)'),
     'heading-offset': re.compile(r'heading-offset=([0-5])'),
 }
@@ -74,9 +74,9 @@ def get_file_content(markdown, abs_src_path):
 
         #   boolean options
         bool_options = {
-            'preserve_includer_indent': {
+            'preserve-includer-indent': {
                 'value': True,
-                'regex': ARGUMENT_REGEXES['preserve_includer_indent'],
+                'regex': ARGUMENT_REGEXES['preserve-includer-indent'],
             },
             'dedent': {
                 'value': False,
@@ -113,8 +113,8 @@ def get_file_content(markdown, abs_src_path):
         new_text_to_include = get_file_content(text_to_include, file_path_abs)
 
         if text_to_include == new_text_to_include:
-            # At last inclusion, allow good practice of having a final newline
-            #   in the file
+            # at last inclusion, allow good practice of having a final newline
+            # in the file
             if text_to_include.endswith('\n'):
                 text_to_include = text_to_include[:-1]
         else:
@@ -124,7 +124,7 @@ def get_file_content(markdown, abs_src_path):
             text_to_include = textwrap.dedent(text_to_include)
 
         # Includer indentation preservation
-        if bool_options['preserve_includer_indent']['value']:
+        if bool_options['preserve-includer-indent']['value']:
             text_to_include = ''.join(
                 _includer_indent + line
                 for line in text_to_include.splitlines(keepends=True)
@@ -151,17 +151,17 @@ def get_file_content(markdown, abs_src_path):
 
         #   boolean options
         bool_options = {
-            'rewrite_relative_urls': {
+            'rewrite-relative-urls': {
                 'value': True,
-                'regex': ARGUMENT_REGEXES['rewrite_relative_urls'],
+                'regex': ARGUMENT_REGEXES['rewrite-relative-urls'],
             },
             'comments': {
                 'value': True,
                 'regex': ARGUMENT_REGEXES['comments'],
             },
-            'preserve_includer_indent': {
+            'preserve-includer-indent': {
                 'value': True,
-                'regex': ARGUMENT_REGEXES['preserve_includer_indent'],
+                'regex': ARGUMENT_REGEXES['preserve-includer-indent'],
             },
             'dedent': {
                 'value': False,
@@ -196,20 +196,20 @@ def get_file_content(markdown, abs_src_path):
             end = process.interpret_escapes(end_match.group(1))
             text_to_include, _, _ = text_to_include.partition(end)
 
-        # Relative URLs rewriting
-        if bool_options['rewrite_relative_urls']['value']:
+        # relative URLs rewriting
+        if bool_options['rewrite-relative-urls']['value']:
             text_to_include = process.rewrite_relative_urls(
                 text_to_include,
                 source_path=file_path_abs,
                 destination_path=page_src_path,
             )
 
-        # Dedent
+        # dedent
         if bool_options['dedent']:
             text_to_include = textwrap.dedent(text_to_include)
 
-        # Includer indentation preservation
-        if bool_options['preserve_includer_indent']['value']:
+        # includer indentation preservation
+        if bool_options['preserve-includer-indent']['value']:
             text_to_include = ''.join(
                 _includer_indent + line
                 for line in text_to_include.splitlines(keepends=True)

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -14,21 +14,23 @@ from mkdocs_include_markdown_plugin.event import on_page_markdown
         'expected_result',
     ),
     (
-        (
+        pytest.param(
             '# Header\n\n{% include "{filepath}" %}\n',
             'This must be included.',
             '# Header\n\nThis must be included.\n',
+            id='simple case',
         ),
 
         # Newline at the end of the included content
-        (
+        pytest.param(
             '# Header\n\n{% include "{filepath}" %}\n',
             'This must be included.\n',
             '# Header\n\nThis must be included.\n',
+            id='newline at end of included',
         ),
 
         # Start and end options
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -45,10 +47,11 @@ This must be ignored also.
 
 This must be included.
 ''',
+            id='start/end',
         ),
 
         # Start and end options with escaped special characters
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -65,10 +68,11 @@ This must be ignored also.
 
 This must be included.
 ''',
+            id='start/end (escaped special characters)',
         ),
 
         # Start and end options with unescaped special characters
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -85,10 +89,11 @@ This must be ignored also.
 
 This must be included.
 ''',
+            id='start/end (unescaped special characters)',
         ),
 
         # Preserve included indent
-        (
+        pytest.param(
             '''1. Ordered list item
     {%
       include "{filepath}"
@@ -99,10 +104,11 @@ This must be included.
             '''1. Ordered list item
     - Unordered sublist item
     - Other unordered sublist item''',
+            id='preserve included indent',
         ),
 
         # Preserve includer indent
-        (
+        pytest.param(
             '''1. Ordered list item
     {%
       include "{filepath}"
@@ -114,10 +120,11 @@ This must be included.
     - First unordered sublist item
     - Second unordered sublist item
     - Third unordered sublist item''',
+            id='preserve includer indent',
         ),
 
-        # Options custom ordering
-        (
+        # Custom options ordering
+        pytest.param(
             '''1. Ordered list item
     {%
       include "{filepath}"
@@ -131,10 +138,11 @@ This must be included.
             '''1. Ordered list item
     - First unordered sublist item
     - Second unordered sublist item''',
+            id='custom options ordering',
         ),
 
         # Content unindentation
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -151,10 +159,11 @@ This must be included.
 - Bar
     - Baz
 ''',
+            id='dedent=true',
         ),
 
         # Content unindentation + preserve includer indent
-        (
+        pytest.param(
             '''# Header
 
     {%
@@ -172,6 +181,7 @@ This must be included.
     - Bar
         - Baz
 ''',
+            id='dedent=true,preserve-includer-indent=true',
         ),
     ),
 )

--- a/tests/test_include.py
+++ b/tests/test_include.py
@@ -92,7 +92,7 @@ This must be included.
             '''1. Ordered list item
     {%
       include "{filepath}"
-      preserve_includer_indent=false
+      preserve-includer-indent=false
     %}''',
             '''- Unordered sublist item
     - Other unordered sublist item''',
@@ -121,7 +121,7 @@ This must be included.
             '''1. Ordered list item
     {%
       include "{filepath}"
-      preserve_includer_indent=true
+      preserve-includer-indent=true
       end="<!--end-->"
       start="<!--start-->"
     %}''',
@@ -160,7 +160,7 @@ This must be included.
     {%
       include "{filepath}"
       dedent=true
-      preserve_includer_indent=true
+      preserve-includer-indent=true
     %}
 ''',
             '''        - Foo
@@ -213,7 +213,7 @@ def test_include_filepath_error(page, tmp_path):
 @pytest.mark.parametrize(
     'opt_name',
     (
-        'preserve_includer_indent',
+        'preserve-includer-indent',
         'dedent',
     ),
 )

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -159,7 +159,7 @@ This must be included.
     {%
       include-markdown "{filepath}"
       comments=false
-      preserve_includer_indent=false
+      preserve-includer-indent=false
     %}''',
             '''- Unordered sublist item
     - Other unordered sublist item''',
@@ -189,7 +189,7 @@ This must be included.
             '''1. Ordered list item
     {%
       include-markdown "{filepath}"
-      preserve_includer_indent=true
+      preserve-includer-indent=true
       end="<!--end-->"
       comments=false
       start="<!--start-->"
@@ -230,7 +230,7 @@ This must be included.
     {%
       include-markdown "{filepath}"
       dedent=true
-      preserve_includer_indent=true
+      preserve-includer-indent=true
       comments=false
     %}
 ''',
@@ -396,7 +396,7 @@ def test_include_markdown_relative_rewrite(
     rewrite_relative_urls,
 ):
     option_value = '' if rewrite_relative_urls is None else (
-        'rewrite_relative_urls=' + rewrite_relative_urls
+        'rewrite-relative-urls=' + rewrite_relative_urls
     )
 
     includer_path = tmp_path / 'includer.md'
@@ -467,9 +467,9 @@ def test_include_markdown_relative_rewrite(
 @pytest.mark.parametrize(
     'opt_name',
     (
-        'rewrite_relative_urls',
+        'rewrite-relative-urls',
         'comments',
-        'preserve_includer_indent',
+        'preserve-includer-indent',
         'dedent',
     ),
 )

--- a/tests/test_include_markdown.py
+++ b/tests/test_include_markdown.py
@@ -13,7 +13,7 @@ from mkdocs_include_markdown_plugin.event import on_page_markdown
     ),
     (
         # Simple case
-        (
+        pytest.param(
             '# Header\n\n{% include-markdown "{filepath}" %}\n',
             'This must be included.',
             '''# Header
@@ -22,10 +22,11 @@ from mkdocs_include_markdown_plugin.event import on_page_markdown
 This must be included.
 <!-- END INCLUDE -->
 ''',
+            id='simple case',
         ),
 
         # Start option
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -43,10 +44,11 @@ This must be included.''',
 This must be included.
 <!-- END INCLUDE -->
 ''',
+            id='start',
         ),
 
         # End option
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -64,10 +66,11 @@ This must be included.
 
 <!-- END INCLUDE -->
 ''',
+            id='end',
         ),
 
         # Start and end options
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -89,10 +92,11 @@ This must be included.
 
 <!-- END INCLUDE -->
 ''',
+            id='start/end',
         ),
 
         # Start and end with escaped special characters
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -114,10 +118,11 @@ This must be included.
 
 <!-- END INCLUDE -->
 ''',
+            id='start/end (escaped special characters)',
         ),
 
         # Start and end with unescaped special characters
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -141,20 +146,22 @@ This must be included.
 
 <!-- END INCLUDE -->
 ''',
+            id='start/end (unescaped special characters)',
         ),
 
         # Exclude start and end comments
-        (
+        pytest.param(
             '''{%
   include-markdown "{filepath}"
   comments=false
 %}''',
             '''Foo''',
             '''Foo''',
+            id='comments=false',
         ),
 
-        # Preserve included indent
-        (
+        # Don't preserve included indent
+        pytest.param(
             '''1. Ordered list item
     {%
       include-markdown "{filepath}"
@@ -166,10 +173,11 @@ This must be included.
             '''1. Ordered list item
     - Unordered sublist item
     - Other unordered sublist item''',
+            id='preserve-includer-indent=false',
         ),
 
         # Preserve includer indent
-        (
+        pytest.param(
             '''1. Ordered list item
     {%
       include-markdown "{filepath}"
@@ -182,10 +190,11 @@ This must be included.
     - First unordered sublist item
     - Second unordered sublist item
     - Third unordered sublist item''',
+            id='preserve-includer-indent=true (default)',
         ),
 
-        # Options custom ordering
-        (
+        # Custom options ordering
+        pytest.param(
             '''1. Ordered list item
     {%
       include-markdown "{filepath}"
@@ -200,10 +209,11 @@ This must be included.
             '''1. Ordered list item
     - First unordered sublist item
     - Second unordered sublist item''',
+            id='custom options ordering',
         ),
 
         # Content unindentation
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -221,10 +231,11 @@ This must be included.
 - Bar
     - Baz
 ''',
+            id='dedent=true',
         ),
 
         # Content unindentation + preserve includer indent
-        (
+        pytest.param(
             '''# Header
 
     {%
@@ -243,10 +254,11 @@ This must be included.
     - Bar
         - Baz
 ''',
+            id='dedent=true,preserve-includer-indent=true',
         ),
 
         # Markdown heading offset 1
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -265,9 +277,10 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
+            id='heading-offset=1',
         ),
         # Markdown heading offset 2
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -286,9 +299,11 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
+            id='heading-offset=2',
         ),
+
         # Markdown heading no offset
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -306,9 +321,11 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
+            id='no heading-offset (default)',
         ),
+
         # Markdown heading zero offset
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -327,9 +344,10 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
+            id='heading-offset=0',
         ),
         # Markdown heading offset string
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -348,6 +366,7 @@ Example data''',
 Example data
 <!-- END INCLUDE -->
 ''',
+            id='heading-offset=<str>',
         ),
     ),
 )

--- a/tests/test_nested_includes.py
+++ b/tests/test_nested_includes.py
@@ -14,7 +14,7 @@ from mkdocs_include_markdown_plugin.event import on_page_markdown
     ),
     (
         # Includer -> Markdown -> Markdown
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -35,10 +35,11 @@ Some text from second includer.
 
 Some test from final included.
 ''',
+            id='includer -> markdown -> markdown',
         ),
 
         # Includer -> Markdown -> file
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -58,10 +59,11 @@ Some text from second includer.
 
 Some test from final included.
 ''',
+            id='includer -> markdown -> file',
         ),
 
         # Includer -> file -> file
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -80,10 +82,11 @@ Some text from second includer.
 
 Some test from final included.
 ''',
+            id='includer -> file -> file',
         ),
 
         # Includer -> file -> Markdown
-        (
+        pytest.param(
             '''# Header
 
 {%
@@ -109,6 +112,7 @@ Some text from second includer.
 
 Some test from final included.
 ''',
+            id='includer -> file -> markdown',
         ),
     ),
 )


### PR DESCRIPTION
- `preserve_includer_indent` is defined now as `preserve-includer-indent`.
- `rewrite_relative_urls` is defined now as `rewrite-relative-urls`.