### PR TITLE
Fix codeblocks added in wrong places rewriting relative URLs

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.2.2
+current_version = 3.2.3
 
 [bumpversion:file:mkdocs_include_markdown_plugin/__init__.py]
 

--- a/mkdocs_include_markdown_plugin/__init__.py
+++ b/mkdocs_include_markdown_plugin/__init__.py
@@ -1,2 +1,2 @@
 __title__ = 'mkdocs_include_markdown_plugin'
-__version__ = '3.2.2'
+__version__ = '3.2.3'

--- a/mkdocs_include_markdown_plugin/process.py
+++ b/mkdocs_include_markdown_plugin/process.py
@@ -112,11 +112,11 @@ def transform_p_by_p_skipping_codeblocks(markdown, func):
                 lstripped_line.startswith('~~~'),
             ]):
                 _inside_fcodeblock = True
-                _current_fcodeblock_delimiter = line[:3]
-                lines.append(line)
+                _current_fcodeblock_delimiter = lstripped_line[:3]
                 if current_paragraph:
                     process_current_paragraph_lines()
                     current_paragraph = ''
+                lines.append(line)
             elif (
                 # 5 and 2 including newline character
                 (line.startswith('    ') and len(line) == 5) or

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mkdocs_include_markdown_plugin
-version = 3.2.2
+version = 3.2.3
 description = Mkdocs Markdown includer plugin.
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Fixes regression produced by [v3.2.2](https://github.com/mondeja/mkdocs-include-markdown-plugin/releases/tag/v3.2.2).