### PR TITLE
refactor: remove duplicate code

### DIFF
--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -274,7 +274,7 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.error(
-                    "Invalid empty 'end' argument in '{directive_name}'"
+                    f"Invalid empty 'end' argument in '{directive_name}'"
                     f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno}',
                 )

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -120,7 +120,7 @@ def get_file_content(
 
     def found_include_tag(match, include_markdown=False):
         directive_match_start = match.start()
-        # incl_keyword is used for proper error reporting.
+        # directive_name is used for proper error reporting.
         directive_name = (
             'include' if not include_markdown
             else 'include-markdown'
@@ -274,7 +274,7 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.error(
-                    "Invalid empty 'end' argument in '{incl_keyword}'"
+                    "Invalid empty 'end' argument in '{directive_name}'"
                     f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno}',
                 )

--- a/mkdocs_include_markdown_plugin/event.py
+++ b/mkdocs_include_markdown_plugin/event.py
@@ -118,8 +118,13 @@ def get_file_content(
     cumulative_heading_offset=0,
 ):
 
-    def found_include_tag(match):
+    def found_include_tag(match, include_markdown=False):
         directive_match_start = match.start()
+        # incl_keyword is used for proper error reporting.
+        directive_name = (
+            'include' if not include_markdown
+            else 'include-markdown'
+        )
 
         _includer_indent = match.group('_includer_indent')
 
@@ -130,7 +135,7 @@ def get_file_content(
                 directive_match_start,
             )
             logger.error(
-                "Found no path passed including with 'include'"
+                f"Found no path passed including with '{directive_name}'"
                 f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                 f':{lineno}',
             )
@@ -160,12 +165,12 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.error(
-                    "Invalid empty 'exclude' argument in 'include' directive"
-                    f' at {os.path.relpath(page_src_path, docs_dir)}:{lineno}',
+                    f"Invalid empty 'exclude' argument in '{directive_name}'"
+                    f' directive at {os.path.relpath(page_src_path, docs_dir)}'
+                    f':{lineno}',
                 )
                 ignore_paths = []
             else:
-
                 if os.path.isabs(exclude_string):
                     exclude_globstr = exclude_string
                 else:
@@ -194,6 +199,7 @@ def get_file_content(
             )
             return ''
 
+        # Common options for 'include' and 'include-markdown' directives
         bool_options = {
             'preserve-includer-indent': {
                 'value': True,
@@ -208,224 +214,18 @@ def get_file_content(
                 'regex': ARGUMENT_REGEXES['trailing-newlines'],
             },
         }
-
-        for arg_name, arg in bool_options.items():
-            match = re.search(arg['regex'], arguments_string)
-            if match is None:
-                continue
-            try:
-                bool_options[arg_name]['value'] = TRUE_FALSE_STR_BOOL[
-                    match.group(1) or TRUE_FALSE_BOOL_STR[arg['value']]
-                ]
-            except KeyError:
-                lineno = lineno_from_content_start(
-                    markdown,
-                    directive_match_start,
-                )
-                logger.error(
-                    f"Invalid value for '{arg_name}' argument of 'include'"
-                    f' directive at {os.path.relpath(page_src_path, docs_dir)}'
-                    f':{lineno}. Possible values are true or false.',
-                )
-                return ''
-
-        start_match = re.search(ARGUMENT_REGEXES['start'], arguments_string)
-        if start_match:
-            start = parse_string_argument(start_match)
-            if start is None:
-                lineno = lineno_from_content_start(
-                    markdown,
-                    directive_match_start,
-                )
-                logger.error(
-                    "Invalid empty 'start' argument in 'include' directive at "
-                    f'{os.path.relpath(page_src_path, docs_dir)}:{lineno}',
-                )
-        else:
-            start = None
-
-        end_match = re.search(ARGUMENT_REGEXES['end'], arguments_string)
-        if end_match:
-            end = parse_string_argument(end_match)
-            if end is None:
-                lineno = lineno_from_content_start(
-                    markdown,
-                    directive_match_start,
-                )
-                logger.error(
-                    "Invalid empty 'end' argument in 'include' directive at "
-                    f'{os.path.relpath(page_src_path, docs_dir)}:{lineno}',
-                )
-        else:
-            end = None
-
-        text_to_include = ''
-        expected_but_any_found = [start is not None, end is not None]
-        for file_path in file_paths_to_include:
-            with open(file_path, encoding='utf-8') as f:
-                new_text_to_include = f.read()
-
-            if start is not None or end is not None:
-                new_text_to_include, *expected_not_found = (
-                    process.filter_inclusions(
-                        start,
-                        end,
-                        new_text_to_include,
-                    )
-                )
-                for i in range(2):
-                    if expected_but_any_found[i] and not expected_not_found[i]:
-                        expected_but_any_found[i] = False
-
-            # nested includes
-            new_text_to_include = get_file_content(
-                new_text_to_include,
-                file_path,
-                docs_dir,
-                include_tag_regex,
-                include_markdown_tag_regex,
-            )
-
-            # trailing newlines right stripping
-            if not bool_options['trailing-newlines']['value']:
-                new_text_to_include = process.rstrip_trailing_newlines(
-                    new_text_to_include,
-                )
-
-            if bool_options['dedent']:
-                new_text_to_include = textwrap.dedent(new_text_to_include)
-
-            # includer indentation preservation
-            if bool_options['preserve-includer-indent']['value']:
-                new_text_to_include = ''.join(
-                    _includer_indent + line
-                    for line in new_text_to_include.splitlines(keepends=True)
-                )
-            else:
-                new_text_to_include = _includer_indent + new_text_to_include
-
-            text_to_include += new_text_to_include
-
-        # warn if expected start or ends haven't been found in included content
-        for i, argname in enumerate(['start', 'end']):
-            if expected_but_any_found[i]:
-                value = locals()[argname]
-                readable_files_to_include = ', '.join([
-                    os.path.relpath(fpath, docs_dir)
-                    for fpath in file_paths_to_include
-                ])
-                plural_suffix = 's' if len(file_paths_to_include) > 1 else ''
-                lineno = lineno_from_content_start(
-                    markdown,
-                    directive_match_start,
-                )
-                logger.warning(
-                    f"Delimiter {argname} '{value}' of 'include'"
-                    f' directive at {os.path.relpath(page_src_path, docs_dir)}'
-                    f':{lineno} not detected in the file{plural_suffix}'
-                    f' {readable_files_to_include}',
-                )
-
-        return text_to_include
-
-    def found_include_markdown_tag(match):
-        directive_match_start = match.start()
-
-        _includer_indent = match.group('_includer_indent')
-
-        filename, raw_filename = parse_filename_argument(match)
-        if filename is None:
-            lineno = lineno_from_content_start(
-                markdown,
-                directive_match_start,
-            )
-            logger.error(
-                "Found no path passed including with 'include-markdown'"
-                f' directive at {os.path.relpath(page_src_path, docs_dir)}'
-                f':{lineno}',
-            )
-            return ''
-
-        arguments_string = match.group('arguments')
-
-        if os.path.isabs(filename):
-            file_path_glob = filename
-        else:
-            file_path_glob = os.path.join(
-                os.path.abspath(os.path.dirname(page_src_path)),
-                filename,
-            )
-
-        exclude_match = re.search(
-            ARGUMENT_REGEXES['exclude'],
-            arguments_string,
-        )
-        if exclude_match is None:
-            ignore_paths = []
-        else:
-            exclude_string = parse_string_argument(exclude_match)
-            if exclude_string is None:
-                lineno = lineno_from_content_start(
-                    markdown,
-                    directive_match_start,
-                )
-                logger.error(
-                    "Invalid empty 'exclude' argument in 'include-markdown'"
-                    f' directive at {os.path.relpath(page_src_path, docs_dir)}'
-                    f':{lineno}',
-                )
-                ignore_paths = []
-            else:
-                if os.path.isabs(exclude_string):
-                    exclude_globstr = exclude_string
-                else:
-                    exclude_globstr = os.path.realpath(
-                        os.path.join(
-                            os.path.abspath(os.path.dirname(page_src_path)),
-                            exclude_string,
-                        ),
-                    )
-                ignore_paths = glob.glob(exclude_globstr)
-
-        file_paths_to_include = process.filter_paths(
-            glob.iglob(file_path_glob, recursive=True),
-            ignore_paths=ignore_paths,
-        )
-
-        if not file_paths_to_include:
-            lineno = lineno_from_content_start(
-                markdown,
-                directive_match_start,
-            )
-            logger.error(
-                f"No files found including '{raw_filename}' at"
-                f' {os.path.relpath(page_src_path, docs_dir)}'
-                f':{lineno}',
-            )
-            return ''
-
-        bool_options = {
-            'rewrite-relative-urls': {
-                'value': True,
-                'regex': ARGUMENT_REGEXES['rewrite-relative-urls'],
-            },
-            'comments': {
-                'value': True,
-                'regex': ARGUMENT_REGEXES['comments'],
-            },
-            'preserve-includer-indent': {
-                'value': True,
-                'regex': ARGUMENT_REGEXES['preserve-includer-indent'],
-            },
-            'dedent': {
-                'value': False,
-                'regex': ARGUMENT_REGEXES['dedent'],
-            },
-            'trailing-newlines': {
-                'value': True,
-                'regex': ARGUMENT_REGEXES['trailing-newlines'],
-            },
-        }
+        # Specific options for 'include-markdown' directive
+        if include_markdown:
+            bool_options.update({
+                'rewrite-relative-urls': {
+                    'value': True,
+                    'regex': ARGUMENT_REGEXES['rewrite-relative-urls'],
+                },
+                'comments': {
+                    'value': True,
+                    'regex': ARGUMENT_REGEXES['comments'],
+                },
+            })
 
         for arg_name, arg in bool_options.items():
             match = re.search(arg['regex'], arguments_string)
@@ -442,7 +242,7 @@ def get_file_content(
                 )
                 logger.error(
                     f"Invalid value for '{arg_name}' argument of"
-                    " 'include-markdown' directive at"
+                    f" '{directive_name}' directive at"
                     f' {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno}. Possible values are true or false.',
                 )
@@ -458,7 +258,7 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.error(
-                    "Invalid empty 'start' argument in 'include-markdown'"
+                    f"Invalid empty 'start' argument in '{directive_name}'"
                     f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno}',
                 )
@@ -474,21 +274,22 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.error(
-                    "Invalid empty 'end' argument in 'include-markdown'"
+                    "Invalid empty 'end' argument in '{incl_keyword}'"
                     f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno}',
                 )
         else:
             end = None
 
-        # heading offset
-        offset = 0
-        offset_match = re.search(
-            ARGUMENT_REGEXES['heading-offset'],
-            arguments_string,
-        )
-        if offset_match:
-            offset += int(offset_match.group(1))
+        # heading offset (only for 'include-markdown' directives)
+        if include_markdown:
+            offset = 0
+            offset_match = re.search(
+                ARGUMENT_REGEXES['heading-offset'],
+                arguments_string,
+            )
+            if offset_match:
+                offset += int(offset_match.group(1))
 
         text_to_include = ''
 
@@ -529,8 +330,10 @@ def get_file_content(
                     new_text_to_include,
                 )
 
-            # relative URLs rewriting
-            if bool_options['rewrite-relative-urls']['value']:
+            # relative URLs rewriting (only for 'include-markdown' directives)
+            if include_markdown and bool_options[
+                'rewrite-relative-urls'
+            ]['value']:
                 new_text_to_include = process.rewrite_relative_urls(
                     new_text_to_include,
                     source_path=file_path,
@@ -550,7 +353,7 @@ def get_file_content(
             else:
                 new_text_to_include = _includer_indent + new_text_to_include
 
-            if offset_match:
+            if include_markdown and offset_match:
                 new_text_to_include = process.increase_headings_offset(
                     new_text_to_include,
                     offset=offset + cumulative_heading_offset,
@@ -572,13 +375,13 @@ def get_file_content(
                     directive_match_start,
                 )
                 logger.warning(
-                    f"Delimiter {argname} '{value}' of 'include-markdown'"
+                    f"Delimiter {argname} '{value}' of '{directive_name}'"
                     f' directive at {os.path.relpath(page_src_path, docs_dir)}'
                     f':{lineno} not detected in the file{plural_suffix}'
                     f' {readable_files_to_include}',
                 )
 
-        if not bool_options['comments']['value']:
+        if not (include_markdown and bool_options['comments']['value']):
             return text_to_include
 
         separator = '\n' if bool_options['trailing-newlines']['value'] else ''
@@ -596,12 +399,12 @@ def get_file_content(
 
     markdown = re.sub(
         include_tag_regex,
-        found_include_tag,
+        lambda m: found_include_tag(m, include_markdown=False),
         markdown,
     )
     return re.sub(
         include_markdown_tag_regex,
-        found_include_markdown_tag,
+        lambda m: found_include_tag(m, include_markdown=True),
         markdown,
     )
 


### PR DESCRIPTION
The `found_include_tag` and `found_include_markdown_tag` methods
were very similar. This change merges the two methods in one with an
additionnal parameter and saves ~200 lines of code.