### PR TITLE
fix: Run on_page_markdown event "first"

### DIFF
--- a/mkdocs_include_markdown_plugin/plugin.py
+++ b/mkdocs_include_markdown_plugin/plugin.py
@@ -58,7 +58,7 @@ else:
                 SERVER = server
                 self._watch_included_files()
 
-        @mkdocs.plugins.event_priority(-100)
+        @mkdocs.plugins.event_priority(100)
         def on_page_markdown(self, markdown, page, **kwargs):
             global WATCHING_FILES
             if WATCHING_FILES is None:


### PR DESCRIPTION
Updates `on_page_markdown` so that it runs before the events from other plugins (as described on https://github.com/mkdocs/mkdocs/pull/2973).

### Extra context

After upgrading to [`mkdocs==1.4.0`](https://github.com/mkdocs/mkdocs/releases/tag/1.4.0) and [`mkdocs-include-markdown-plugin==3.9.0`](https://github.com/mondeja/mkdocs-include-markdown-plugin/releases/tag/v3.9.0), I started having the following errors when building my site:

```bash
$ mkdocs build
INFO     -  Cleaning site directory
INFO     -  Building documentation to directory: /home/prcr/git/docs/site
INFO     -  [macros] - ERROR # _Macro Syntax Error_
            _Line 13 in Markdown file:_ **expected token 'end of statement block', got 'string'**
            ```python
                    include-markdown "../assets/includes/self-hosted-version.txt"
            ```
INFO     -  [macros] - ERROR # _Macro Syntax Error_
            _Line 13 in Markdown file:_ **expected token 'end of statement block', got 'string'**
            ```python
                    include-markdown "../assets/includes/self-hosted-version.txt"
            ```
```

This is because another plugin that I'm using, `mkdocs-macros-plugin==0.7.0`, fails to parse the mkdocs-include-markdown-plugin syntax in the Markdown pages.

In practice, the mkdocs-include-markdown-plugin should be one of the very first plugins to run so that the subsequent plugins work on top of the Markdown that already has the included content, [as described on the README](https://github.com/mondeja/mkdocs-include-markdown-plugin#setup).