### PR TITLE
remove upper bound python requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "4.0.0"
 description = "Mkdocs Markdown includer plugin."
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.7,<3.12"
+requires-python = ">=3.7"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Operating System :: OS Independent",


### PR DESCRIPTION
This change is needed to be able to the install the latest version of this package (4.0.0).
See #135 for more details.