### PR TITLE
Refactor to use new static type checking features

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ Includes the content of a file or a group of files.
 [license-image]: https://img.shields.io/pypi/l/mkdocs-include-markdown-plugin?color=light-green&logo=apache&logoColor=white
 [license-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/LICENSE
 [platformdirs]: https://pypi.org/project/platformdirs/
-[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470
-[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel
+[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470
+[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel
 [es-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/es/README.md
 [fr-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/fr/README.md
 [Bash wildcard globs]: https://facelessuser.github.io/wcmatch/glob/#syntax

--- a/locale/es/README.md
+++ b/locale/es/README.md
@@ -266,8 +266,8 @@ separar este plugin de la documentación de
 [license-image]: https://img.shields.io/pypi/l/mkdocs-include-markdown-plugin?color=light-green&logo=apache&logoColor=white
 [license-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/LICENSE
 [platformdirs]: https://pypi.org/project/platformdirs/
-[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470
-[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel
+[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470
+[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel
 [es-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/es/README.md
 [fr-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/fr/README.md
 [Bash wildcard globs]: https://facelessuser.github.io/wcmatch/glob/#syntax

--- a/locale/es/README.md.po
+++ b/locale/es/README.md.po
@@ -56,12 +56,11 @@ msgstr ""
 "[tests-link]: https://github.com/mondeja/mkdocs-include-markdown-"
 "plugin/actions?query=workflow%3ACI"
 
-msgid "[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470"
-msgstr ""
-"[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470"
+msgid "[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470"
+msgstr "[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470"
 
-msgid "[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel"
-msgstr "[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel"
+msgid "[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel"
+msgstr "[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel"
 
 msgid "Read this document in other languages:"
 msgstr "Lee este documento en otros idiomas:"

--- a/locale/fr/README.md
+++ b/locale/fr/README.md
@@ -263,8 +263,8 @@ autorisations][cibuildwheel-470] pour séparer ce plugin de la documentation de
 [license-image]: https://img.shields.io/pypi/l/mkdocs-include-markdown-plugin?color=light-green&logo=apache&logoColor=white
 [license-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/LICENSE
 [platformdirs]: https://pypi.org/project/platformdirs/
-[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470
-[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel
+[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470
+[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel
 [es-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/es/README.md
 [fr-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-plugin/blob/master/locale/fr/README.md
 [Bash wildcard globs]: https://facelessuser.github.io/wcmatch/glob/#syntax

--- a/locale/fr/README.md.po
+++ b/locale/fr/README.md.po
@@ -69,12 +69,11 @@ msgstr ""
 "[tests-link]: https://github.com/mondeja/mkdocs-include-markdown-"
 "plugin/actions?query=workflow%3ACI"
 
-msgid "[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470"
-msgstr ""
-"[cibuildwheel-470]: https://github.com/joerick/cibuildwheel/issues/470"
+msgid "[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470"
+msgstr "[cibuildwheel-470]: https://github.com/pypa/cibuildwheel/issues/470"
 
-msgid "[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel"
-msgstr "[cibuildwheel-repo-link]: https://github.com/joerick/cibuildwheel"
+msgid "[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel"
+msgstr "[cibuildwheel-repo-link]: https://github.com/pypa/cibuildwheel"
 
 msgid ""
 "[es-readme-link]: https://github.com/mondeja/mkdocs-include-markdown-"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 keywords = ["markdown", "mkdocs", "includer", "plugin"]
-dependencies = ["wcmatch>=8,<9"]
+dependencies = [
+  "mkdocs>=1.4",
+  "wcmatch>=8,<9"
+]
 
 [[project.authors]]
 name = "Joe Rickerby"

--- a/src/mkdocs_include_markdown_plugin/config.py
+++ b/src/mkdocs_include_markdown_plugin/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from mkdocs.config.base import Config
 from mkdocs.config.config_options import (
     ListOfItems,
     Optional,
@@ -9,73 +10,17 @@ from mkdocs.config.config_options import (
 )
 
 
-CONFIG_DEFAULTS = {
-    'opening-tag': '{%',
-    'closing-tag': '%}',
-    'encoding': 'utf-8',
-    'preserve-includer-indent': True,
-    'dedent': False,
-    'trailing-newlines': True,
-    'comments': True,
-    'rewrite-relative-urls': True,
-    'heading-offset': 0,
-    'start': None,
-    'end': None,
-    'exclude': None,
-    'cache': 0,
-}
-
-CONFIG_SCHEME = (
-    (
-        'opening_tag',
-        MkType(str, default=CONFIG_DEFAULTS['opening-tag']),
-    ),
-    (
-        'closing_tag',
-        MkType(str, default=CONFIG_DEFAULTS['closing-tag']),
-    ),
-    (
-        'encoding',
-        MkType(str, default=CONFIG_DEFAULTS['encoding']),
-    ),
-    (
-        'preserve_includer_indent',
-        MkType(bool, default=CONFIG_DEFAULTS['preserve-includer-indent']),
-    ),
-    (
-        'dedent',
-        MkType(bool, default=CONFIG_DEFAULTS['dedent']),
-    ),
-    (
-        'trailing_newlines',
-        MkType(bool, default=CONFIG_DEFAULTS['trailing-newlines']),
-    ),
-    (
-        'comments',
-        MkType(bool, default=CONFIG_DEFAULTS['comments']),
-    ),
-    (
-        'rewrite_relative_urls',
-        MkType(bool, default=CONFIG_DEFAULTS['rewrite-relative-urls']),
-    ),
-    (
-        'heading_offset',
-        MkType(int, default=CONFIG_DEFAULTS['heading-offset']),
-    ),
-    (
-        'start',
-        MkType(str, default=CONFIG_DEFAULTS['start']),
-    ),
-    (
-        'end',
-        MkType(str, default=CONFIG_DEFAULTS['end']),
-    ),
-    (
-        'exclude',
-        Optional(ListOfItems(MkType(str))),
-    ),
-    (
-        'cache',
-        MkType(int, default=CONFIG_DEFAULTS['cache']),
-    ),
-)
+class PluginConfig(Config):  # noqa: D101
+    opening_tag = MkType(str, default='{%')
+    closing_tag = MkType(str, default='%}')
+    encoding = MkType(str, default='utf-8')
+    preserve_includer_indent = MkType(bool, default=True)
+    dedent = MkType(bool, default=False)
+    trailing_newlines = MkType(bool, default=True)
+    comments = MkType(bool, default=True)
+    rewrite_relative_urls = MkType(bool, default=True)
+    heading_offset = MkType(int, default=0)
+    start = Optional(MkType(str))
+    end = Optional(MkType(str))
+    exclude = ListOfItems(MkType(str), default=[])
+    cache = MkType(int, default=0)

--- a/src/mkdocs_include_markdown_plugin/event.py
+++ b/src/mkdocs_include_markdown_plugin/event.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:  # remove this for mypyc compiling
         },
     )
 
+
 @dataclass
 class Settings:  # noqa: D101
     exclude: list[str] | None

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -240,7 +240,7 @@ def rewrite_relative_urls(
 
     def found_href(m: re.Match[str], url_group_index: int = -1) -> str:
         match_start, match_end = m.span(0)
-        href = m.group(url_group_index)
+        href = m[url_group_index]
         href_start, href_end = m.span(url_group_index)
         rewritten_url = rewrite_url(href)
         return (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import pytest
+from mkdocs_include_markdown_plugin.plugin import IncludeMarkdownPlugin
 
 
 TESTS_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -23,3 +24,13 @@ def page():
             },
         )
     return _page
+
+
+@pytest.fixture
+def plugin(request):
+    """Populate a plugin, with optional indirect config parameter."""
+    plugin = IncludeMarkdownPlugin()
+    errors, warnings = plugin.load_config(getattr(request, 'param', {}))
+    assert errors == []
+    assert warnings == []
+    return plugin

--- a/tests/test_integration/test_cache_integration.py
+++ b/tests/test_integration/test_cache_integration.py
@@ -41,6 +41,7 @@ def test_page_included_by_url_is_cached(
     expected_result,
     page,
     tmp_path,
+    plugin,
 ):
     cache_dir = get_cache_directory()
     if not CACHE_AVAILABLE:
@@ -64,6 +65,7 @@ def test_page_included_by_url_is_cached(
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
             http_cache=cache,
         )
 

--- a/tests/test_unit/test_arguments.py
+++ b/tests/test_unit/test_arguments.py
@@ -33,7 +33,14 @@ from testing_helpers import parametrize_directives, unix_only
         ),
     ),
 )
-def test_invalid_bool_arguments(directive, arguments, page, tmp_path, caplog):
+def test_invalid_bool_arguments(
+    directive,
+    arguments,
+    page,
+    tmp_path,
+    plugin,
+    caplog,
+):
     for argument_name in arguments:
         page_to_include_filepath = tmp_path / 'included.md'
         page_to_include_filepath.write_text('Included\n')
@@ -48,6 +55,7 @@ def test_invalid_bool_arguments(directive, arguments, page, tmp_path, caplog):
     %}}''',
                 page(tmp_path / filename),
                 tmp_path,
+                plugin,
             )
         assert str(exc.value) == (
             f"Invalid value for '{argument_name}' argument of '{directive}'"
@@ -57,7 +65,7 @@ def test_invalid_bool_arguments(directive, arguments, page, tmp_path, caplog):
 
 
 @parametrize_directives
-def test_start_end_mixed_quotes(directive, page, caplog, tmp_path):
+def test_start_end_mixed_quotes(directive, page, caplog, tmp_path, plugin):
     page_to_include_filepath = tmp_path / 'included.md'
     page_to_include_filepath.write_text('''Content that should be ignored
 <!-- "s'tar't" -->
@@ -75,6 +83,7 @@ More content that should be ignored
 %}}''',
         page(tmp_path / 'includer.md'),
         tmp_path,
+        plugin,
     )
     assert result == '\nContent to include\n'
 
@@ -89,6 +98,7 @@ def test_invalid_start_end_arguments(
     page,
     caplog,
     tmp_path,
+    plugin,
 ):
     page_to_include_filepath = tmp_path / 'included.md'
     included_content = '''Content that should be ignored
@@ -109,6 +119,7 @@ More content that should be ignored
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
     assert str(exc.value) == (
         f"Invalid empty '{argument}' argument in '{directive}'"
@@ -120,7 +131,7 @@ More content that should be ignored
 
 @unix_only
 @parametrize_directives
-def test_exclude_double_quote_escapes(directive, page, tmp_path):
+def test_exclude_double_quote_escapes(directive, page, tmp_path, plugin):
     drectory_to_include = tmp_path / 'exclude_double_quote_escapes'
     drectory_to_include.mkdir()
 
@@ -142,13 +153,14 @@ def test_exclude_double_quote_escapes(directive, page, tmp_path):
 %}}''',
         page(tmp_path / 'includer.md'),
         tmp_path,
+        plugin,
     )
     assert result == 'Content that should be included\n'
 
 
 @unix_only
 @parametrize_directives
-def test_invalid_exclude_argument(directive, page, tmp_path, caplog):
+def test_invalid_exclude_argument(directive, page, tmp_path, caplog, plugin):
     drectory_to_include = tmp_path / 'exclude_double_quote_escapes'
     drectory_to_include.mkdir()
 
@@ -168,6 +180,7 @@ def test_invalid_exclude_argument(directive, page, tmp_path, caplog):
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
 
     assert len(caplog.records) == 0
@@ -178,7 +191,7 @@ def test_invalid_exclude_argument(directive, page, tmp_path, caplog):
 
 
 @parametrize_directives
-def test_empty_encoding_argument(directive, page, tmp_path, caplog):
+def test_empty_encoding_argument(directive, page, tmp_path, plugin, caplog):
     page_to_include_filepath = tmp_path / 'included.md'
     page_to_include_filepath.write_text('Content to include')
 
@@ -191,6 +204,7 @@ def test_empty_encoding_argument(directive, page, tmp_path, caplog):
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
 
     assert len(caplog.records) == 0
@@ -224,6 +238,7 @@ def test_invalid_heading_offset_arguments(
     exception_message,
     page,
     tmp_path,
+    plugin,
     caplog,
 ):
     page_to_include_filepath = tmp_path / 'included.md'
@@ -238,6 +253,7 @@ def test_invalid_heading_offset_arguments(
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
 
     assert len(caplog.records) == 0
@@ -256,7 +272,7 @@ class TestFilename:
     @parametrize_directives
     @pytest.mark.parametrize('filename', double_quoted_filenames)
     def test_not_escaped_double_quotes(
-        self, directive, filename, page, tmp_path, caplog,
+        self, directive, filename, page, tmp_path, plugin, caplog,
     ):
         page_to_include_filepath = tmp_path / filename
         page_to_include_filepath.write_text('Foo\n')
@@ -266,6 +282,7 @@ class TestFilename:
                 f'{{% {directive} "{page_to_include_filepath}" %}}',
                 page(tmp_path / 'includer.md'),
                 tmp_path,
+                plugin,
             )
 
         assert len(caplog.records) == 0
@@ -278,7 +295,7 @@ class TestFilename:
     @parametrize_directives
     @pytest.mark.parametrize('filename', double_quoted_filenames)
     def test_escaped_double_quotes(
-        self, directive, filename, page, tmp_path,
+        self, directive, filename, page, tmp_path, plugin,
     ):
         included_content = 'Foo\n'
         page_to_include_filepath = tmp_path / filename
@@ -295,13 +312,14 @@ class TestFilename:
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
         assert result == included_content
 
     @parametrize_directives
     @pytest.mark.parametrize('filename', single_quoted_filenames)
     def test_escaped_single_quotes(
-        self, filename, directive, page, tmp_path,
+        self, filename, directive, page, tmp_path, plugin,
     ):
         included_content = 'Foo\n'
         page_to_include_filepath = tmp_path / filename
@@ -318,6 +336,7 @@ class TestFilename:
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
         assert result == included_content
 
@@ -325,7 +344,7 @@ class TestFilename:
     @parametrize_directives
     @pytest.mark.parametrize('filename', double_quoted_filenames)
     def test_unescaped_double_quotes(
-        self, filename, directive, page, tmp_path,
+        self, filename, directive, page, tmp_path, plugin,
     ):
         included_content = 'Foo\n'
         page_to_include_filepath = tmp_path / filename
@@ -338,13 +357,14 @@ class TestFilename:
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
         assert result == included_content
 
     @parametrize_directives
     @pytest.mark.parametrize('filename', single_quoted_filenames)
     def test_unescaped_single_quotes(
-        self, filename, directive, page, tmp_path,
+        self, filename, directive, page, tmp_path, plugin,
     ):
         included_content = 'Foo\n'
         page_to_include_filepath = tmp_path / filename
@@ -357,6 +377,7 @@ class TestFilename:
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
         assert result == included_content
 
@@ -372,7 +393,15 @@ class TestFilename:
         'escape', (True, False), ids=('escape=True', 'escape=False'),
     )
     def test_mixed_quotes(
-        self, filename, quote, escape, directive, page, tmp_path, caplog,
+        self,
+        filename,
+        quote,
+        escape,
+        directive,
+        page,
+        tmp_path,
+        plugin,
+        caplog,
     ):
         included_content = 'Foo\n'
         page_to_include_filepath = tmp_path / filename
@@ -395,6 +424,7 @@ class TestFilename:
             markdown,
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
 
         if escape:
@@ -409,7 +439,7 @@ class TestFilename:
         assert len(caplog.records) == 0
 
     @parametrize_directives
-    def test_no_filename(self, directive, page, tmp_path, caplog):
+    def test_no_filename(self, directive, page, tmp_path, plugin, caplog):
         filename = 'includer.md'
 
         with pytest.raises(PluginError) as exc:
@@ -417,6 +447,7 @@ class TestFilename:
                 f'\n\n{{% {directive} %}}',
                 page(tmp_path / filename),
                 tmp_path,
+                plugin,
             )
 
         assert str(exc.value) == (
@@ -426,7 +457,14 @@ class TestFilename:
         assert len(caplog.records) == 0
 
     @parametrize_directives
-    def test_non_existent_filename(self, directive, page, tmp_path, caplog):
+    def test_non_existent_filename(
+        self,
+        directive,
+        page,
+        tmp_path,
+        plugin,
+        caplog,
+    ):
         page_content = f'''{{%
     {directive} "/path/to/file/that/does/not/exists"
     start="<!--start-here-->"
@@ -441,6 +479,7 @@ class TestFilename:
                 page_content,
                 page(page_filepath),
                 tmp_path,
+                plugin,
             )
 
         assert len(caplog.records) == 0

--- a/tests/test_unit/test_config.py
+++ b/tests/test_unit/test_config.py
@@ -9,7 +9,7 @@ TESTS_ARGUMENTS = (
     'includer_schema',
     'content_to_include',
     'expected_result',
-    'config',
+    'plugin',
 )
 
 
@@ -17,7 +17,7 @@ def _run_test(
     includer_schema,
     content_to_include,
     expected_result,
-    config,
+    plugin,
     page,
     caplog,
     tmp_path,
@@ -47,7 +47,7 @@ def _run_test(
             page_content,
             page(includer_file),
             tmp_path,
-            config,
+            plugin,
         )
         == expected_result
     )
@@ -152,12 +152,13 @@ def _run_test(
             id='custom-comments',
         ),
     ),
+    indirect=['plugin'],
 )
 def test_config_options(
     includer_schema,
     content_to_include,
     expected_result,
-    config,
+    plugin,
     page,
     caplog,
     tmp_path,
@@ -166,7 +167,7 @@ def test_config_options(
         includer_schema,
         content_to_include,
         expected_result,
-        config,
+        plugin,
         page,
         caplog,
         tmp_path,
@@ -193,12 +194,13 @@ def test_config_options(
             id='custom-encoding',
         ),
     ),
+    indirect=['plugin'],
 )
 def test_config_encoding_option(
     includer_schema,
     content_to_include,
     expected_result,
-    config,
+    plugin,
     page,
     caplog,
     tmp_path,
@@ -207,7 +209,7 @@ def test_config_encoding_option(
         includer_schema,
         content_to_include,
         expected_result,
-        config,
+        plugin,
         page,
         caplog,
         tmp_path,

--- a/tests/test_unit/test_encoding.py
+++ b/tests/test_unit/test_encoding.py
@@ -4,7 +4,7 @@ from testing_helpers import parametrize_directives, unix_only
 
 
 @parametrize_directives
-def test_encoding(directive, page, tmp_path):
+def test_encoding(directive, page, tmp_path, plugin):
     page_to_include_file = tmp_path / 'included.md'
     page_to_include_file.write_text('''Á
 <!-- start -->
@@ -24,12 +24,13 @@ Content to include
 %}}''',
             page(tmp_path / 'includer.md'),
             tmp_path,
+            plugin,
         )
 
 
 @unix_only
 @parametrize_directives
-def test_default_encoding(directive, page, tmp_path):
+def test_default_encoding(directive, page, tmp_path, plugin):
     page_to_include_file = tmp_path / 'included.md'
     page_to_include_file.write_text('''Á
 <!-- start -->
@@ -47,13 +48,14 @@ Content to include
 %}}''',
         page(tmp_path / 'includer.md'),
         tmp_path,
+        plugin,
     )
     assert result == '\nContent to include\n'
 
 
 @unix_only
 @parametrize_directives
-def test_explicit_default_encoding(directive, page, tmp_path):
+def test_explicit_default_encoding(directive, page, tmp_path, plugin):
     page_to_include_file = tmp_path / 'included.md'
     page_to_include_file.write_text('''Á
 <!-- start -->
@@ -72,5 +74,6 @@ Content to include
 %}}''',
         page(tmp_path / 'includer.md'),
         tmp_path,
+        plugin,
     )
     assert result == '\nContent to include\n'

--- a/tests/test_unit/test_exclude.py
+++ b/tests/test_unit/test_exclude.py
@@ -62,6 +62,7 @@ from testing_helpers import parametrize_directives, unix_only
 def test_exclude(
     page,
     tmp_path,
+    plugin,
     caplog,
     directive,
     filenames,
@@ -95,6 +96,7 @@ def test_exclude(
         includer_file_content,
         page(includer_file),
         includer_folder,
+        plugin,
     )
 
     if expected_result is None:

--- a/tests/test_unit/test_glob_include.py
+++ b/tests/test_unit/test_glob_include.py
@@ -8,7 +8,7 @@ from testing_helpers import parametrize_directives, unix_only
 
 
 @unix_only
-def test_glob_include_absolute(page, tmp_path):
+def test_glob_include_absolute(page, tmp_path, plugin):
     includer_file = tmp_path / 'includer.txt'
     included_01_file = tmp_path / 'included_01.txt'
     included_02_file = tmp_path / 'included_02.txt'
@@ -41,7 +41,7 @@ barbaz
 '''
 
     assert on_page_markdown(
-        includer_file_content, page(includer_file), tmp_path,
+        includer_file_content, page(includer_file), tmp_path, plugin,
     ) == expected_result
 
 
@@ -150,6 +150,7 @@ def test_glob_include(
     page,
     caplog,
     tmp_path,
+    plugin,
 ):
     includer_file = tmp_path / 'includer.txt'
     included_01_file = tmp_path / 'included_01.txt'
@@ -178,7 +179,7 @@ This 02 must appear only without specifying end.
     included_02_file.write_text(included_02_content)
 
     on_page_markdown(
-        includer_file_content, page(includer_file), tmp_path,
+        includer_file_content, page(includer_file), tmp_path, plugin,
     )
 
     # assert warnings

--- a/tests/test_unit/test_include.py
+++ b/tests/test_unit/test_include.py
@@ -371,6 +371,7 @@ def test_include(
     page,
     caplog,
     tmp_path,
+    plugin,
 ):
     included_file = tmp_path / 'included.md'
     includer_file = tmp_path / 'includer.md'
@@ -387,7 +388,7 @@ def test_include(
     includer_file.write_text(page_content)
 
     assert on_page_markdown(
-        page_content, page(includer_file), tmp_path,
+        page_content, page(includer_file), tmp_path, plugin,
     ) == expected_result
 
     # assert warnings

--- a/tests/test_unit/test_include_markdown.py
+++ b/tests/test_unit/test_include_markdown.py
@@ -772,6 +772,7 @@ def test_include_markdown(
     page,
     caplog,
     tmp_path,
+    plugin,
 ):
     included_file = tmp_path / 'included.md'
     includer_file = tmp_path / 'includer.md'
@@ -796,6 +797,7 @@ def test_include_markdown(
         page_content,
         page(includer_file),
         tmp_path,
+        plugin,
     ) == expected_result
 
     # assert warnings
@@ -823,6 +825,7 @@ def test_include_markdown(
 def test_include_markdown_relative_rewrite(
     page,
     tmp_path,
+    plugin,
     rewrite_relative_urls,
 ):
     option_value = '' if rewrite_relative_urls is None else (
@@ -864,6 +867,7 @@ Here's a [reference link][ref-link].
         includer_path.read_text(),
         page(str(includer_path)),
         docs_dir,
+        plugin,
     )
 
     if rewrite_relative_urls in ['true', None]:
@@ -897,7 +901,7 @@ Here's a [reference link][ref-link].
 '''
 
 
-def test_multiple_includes(page, tmp_path):
+def test_multiple_includes(page, tmp_path, plugin):
     snippet_filepath = tmp_path / 'snippet.md'
     another_filepath = tmp_path / 'another.md'
     includer_file = tmp_path / 'includer.md'
@@ -940,5 +944,5 @@ Another
 Another
 '''
     assert on_page_markdown(
-        includer_content, page(includer_file), tmp_path,
+        includer_content, page(includer_file), tmp_path, plugin,
     ) == expected_result

--- a/tests/test_unit/test_logging.py
+++ b/tests/test_unit/test_logging.py
@@ -12,6 +12,7 @@ def test_start_end_arguments_not_found(
     missing_argument,
     page,
     tmp_path,
+    plugin,
     caplog,
 ):
     included_file_name = 'included.md'
@@ -42,7 +43,7 @@ Included content
 '''
 
     assert on_page_markdown(
-        includer_content, page(includer_file), tmp_path,
+        includer_content, page(includer_file), tmp_path, plugin,
     ) == expected_result
 
     rec = caplog.records[0]

--- a/tests/test_unit/test_nested_includes.py
+++ b/tests/test_unit/test_nested_includes.py
@@ -248,6 +248,7 @@ def test_nested_include(
     page,
     caplog,
     tmp_path,
+    plugin,
 ):
     first_includer_file = tmp_path / 'first-includer.txt'
     second_includer_file = tmp_path / 'second-includer.txt'
@@ -266,7 +267,7 @@ def test_nested_include(
 
     # assert content
     assert on_page_markdown(
-        first_includer_content, page(first_includer_file), tmp_path,
+        first_includer_content, page(first_includer_file), tmp_path, plugin,
     ) == expected_result
 
     # assert warnings
@@ -292,7 +293,7 @@ def test_nested_include(
     assert len(expected_warnings_schemas) == len(caplog.records)
 
 
-def test_nested_include_relpath(page, tmp_path):
+def test_nested_include_relpath(page, tmp_path, plugin):
     docs_dir = tmp_path / 'docs'
     docs_dir.mkdir()
 
@@ -332,4 +333,5 @@ Included content.
         first_includer_content,
         page(first_includer_file),
         docs_dir,
+        plugin,
     ) == expected_result


### PR DESCRIPTION
* Use class-based config and attributes from MkDocs 1.4
* Use dataclass from Python 3.8
* Refactor: put runtime attributes onto the plugin rather than onto the config - also statically typed

Extra: actually depend on MkDocs, it is a dependency
