### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.10"
       - name: Install dependencies
@@ -65,9 +65,9 @@ jobs:
             python-version: "3.12"
             py: py312
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python v${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -81,7 +81,7 @@ jobs:
           coverage combine
           coverage xml
       - name: Upload coverage
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v3.1.4
 
   build-dist:
     if: startsWith(github.ref, 'refs/tags/')
@@ -91,8 +91,8 @@ jobs:
     name: Build package
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-python@v5.0.0
         name: Install Python
         with:
           python-version: "3.10"
@@ -100,7 +100,7 @@ jobs:
         run: pip install -U hatch
       - name: Build package
         run: hatch build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4.0.0
         with:
           path: dist/*
           name: distribution
@@ -110,11 +110,11 @@ jobs:
     needs: build-dist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.0
         with:
           name: distribution
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@v1.8.11
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
@@ -126,7 +126,7 @@ jobs:
     needs: build-dist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Get tag metadata
         id: tag
         run: |
@@ -141,7 +141,7 @@ jobs:
           TAG_BODY="${TAG_BODY//$'\r'/'%0D'}"
           echo "body=$TAG_BODY" >> $GITHUB_OUTPUT
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         id: create-release
         with:
           name: ${{ steps.tag.outputs.title }}
@@ -149,12 +149,12 @@ jobs:
           body: ${{ steps.tag.outputs.body }}
           draft: false
           prerelease: false
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4.1.0
         name: Download builds
         with:
           name: distribution
           path: dist
-      - uses: shogo82148/actions-upload-release-asset@v1
+      - uses: shogo82148/actions-upload-release-asset@v1.7.2
         name: Upload release assets
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}

--- a/.github/workflows/pre-commit-autoupdate.yml
+++ b/.github/workflows/pre-commit-autoupdate.yml
@@ -13,9 +13,9 @@ jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5.0.0
         with:
           python-version: "3.11"
       - name: Install pre-commit
@@ -23,7 +23,7 @@ jobs:
       - name: Run pre-commit autoupdate
         run: pre-commit autoupdate
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5.0.2
         with:
           branch: pre-commit-autoupdate
           title: Upgrade pre-commit hooks revisions

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -13,9 +13,9 @@ jobs:
   action-update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
-      - uses: FantasticFiasco/action-update-license-year@v2
+      - uses: FantasticFiasco/action-update-license-year@v3.0.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gh-actions.yml
+++ b/.github/workflows/update-gh-actions.yml
@@ -9,11 +9,11 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v4.1.1
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}
 
       - name: Run GitHub Actions Version Updater
-        uses: saadmk11/github-actions-version-updater@v0.7.2
+        uses: saadmk11/github-actions-version-updater@v0.8.1
         with:
           token: ${{ secrets.UPDATE_GH_ACTIONS_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[FantasticFiasco/action-update-license-year](https://github.com/FantasticFiasco/action-update-license-year)** published a new release **[v3.0.2](https://github.com/FantasticFiasco/action-update-license-year/releases/tag/v3.0.2)** on 2023-07-05T15:03:55Z
* **[shogo82148/actions-upload-release-asset](https://github.com/shogo82148/actions-upload-release-asset)** published a new release **[v1.7.2](https://github.com/shogo82148/actions-upload-release-asset/releases/tag/v1.7.2)** on 2023-10-16T19:41:32Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.1.0](https://github.com/actions/download-artifact/releases/tag/v4.1.0)** on 2023-12-18T22:24:23Z
* **[softprops/action-gh-release](https://github.com/softprops/action-gh-release)** published a new release **[v0.1.15](https://github.com/softprops/action-gh-release/releases/tag/v0.1.15)** on 2022-11-21T07:00:15Z
* **[peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)** published a new release **[v5.0.2](https://github.com/peter-evans/create-pull-request/releases/tag/v5.0.2)** on 2023-06-14T01:20:17Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.0.0](https://github.com/actions/upload-artifact/releases/tag/v4.0.0)** on 2023-12-14T16:38:02Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.8.11](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.11)** on 2023-11-29T02:41:33Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.0.0](https://github.com/actions/setup-python/releases/tag/v5.0.0)** on 2023-12-06T10:59:28Z
* **[saadmk11/github-actions-version-updater](https://github.com/saadmk11/github-actions-version-updater)** published a new release **[v0.8.1](https://github.com/saadmk11/github-actions-version-updater/releases/tag/v0.8.1)** on 2023-08-13T13:53:59Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[codecov/codecov-action](https://github.com/codecov/codecov-action)** published a new release **[v3.1.4](https://github.com/codecov/codecov-action/releases/tag/v3.1.4)** on 2023-05-15T20:51:01Z
