### PR TITLE
Add new `recursive` argument to `include` directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,9 @@ Includes the content of a file or a group of files.
 - <a name="include_encoding" href="#include_encoding">#</a>
   **encoding** (_utf-8_): Specify the encoding of the included file.
   If not defined `utf-8` will be used.
+- <a name="recursive" href="#recursive">#</a>
+  **recursive** (_true_): When this option is disabled, it will not process
+  included files recursively. Possible values are `true` and `false`.
 
 ##### Examples
 

--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ Includes the content of a file or a group of files.
 - <a name="include_encoding" href="#include_encoding">#</a>
   **encoding** (_utf-8_): Specify the encoding of the included file.
   If not defined `utf-8` will be used.
-- <a name="recursive" href="#recursive">#</a>
-  **recursive** (_true_): When this option is disabled, it will not process
-  included files recursively. Possible values are `true` and `false`.
+- <a name="recursive" href="#include_recursive">#</a>
+  **recursive** (_true_): When this option is disabled, included files are not
+  processed for recursive includes. Possible values are `true` and `false`.
 
 ##### Examples
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ plugins:
       heading_offset: 0
       start: <!--start-->
       end: <!--end-->
+      recursive: true
 ```
 
 #### `opening_tag` and `closing_tag`

--- a/locale/es/README.md
+++ b/locale/es/README.md
@@ -48,6 +48,7 @@ plugins:
       heading_offset: 0
       start: <!--start-->
       end: <!--end-->
+      recursive: true
 ```
 
 #### `opening_tag` y `closing_tag`

--- a/locale/es/README.md
+++ b/locale/es/README.md
@@ -236,6 +236,10 @@ Los valores posibles son `true` y `false`.
 - <a name="include_encoding" href="#include_encoding">#</a> **encoding**
 (*utf-8*): Especifica la codificación del archivo incluído. Si no se define,
 se usará `utf-8`.
+- <a name="recursive" href="#include_recursive">#</a> **recursive** (*true*):
+Cuando esta opción está deshabilitada, los archivos incluidos no son
+procesados para incluir de forma recursiva. Los valores posibles son `true` y
+`false`.
 
 ##### Ejemplos
 

--- a/locale/es/README.md.po
+++ b/locale/es/README.md.po
@@ -406,3 +406,13 @@ msgstr ""
 
 msgid "[pypi-link]: https://pypi.org/project/mkdocs-include-markdown-plugin"
 msgstr "[pypi-link]: https://pypi.org/project/mkdocs-include-markdown-plugin"
+
+msgid ""
+"<a name=\"recursive\" href=\"#include_recursive\">#</a> **recursive** "
+"(*true*): When this option is disabled, included files are not processed for"
+" recursive includes. Possible values are `true` and `false`."
+msgstr ""
+"<a name=\"recursive\" href=\"#include_recursive\">#</a> **recursive** "
+"(*true*): Cuando esta opción está deshabilitada, los archivos incluidos no "
+"son procesados para incluir de forma recursiva. Los valores posibles son "
+"`true` y `false`."

--- a/locale/fr/README.md
+++ b/locale/fr/README.md
@@ -47,6 +47,7 @@ plugins:
       heading_offset: 0
       start: <!--start-->
       end: <!--end-->
+      recursive: true
 ```
 
 #### `opening_tag` et `closing_tag`

--- a/locale/fr/README.md
+++ b/locale/fr/README.md
@@ -235,6 +235,9 @@ valeurs possibles sont `true` et `false`.
 - <a name="include_encoding" href="#include_encoding">#</a> **encoding**
 (*utf-8*): Spécifiez l'encodage du fichier inclus. S'il n'est pas défini,
 `utf-8` sera utilisé.
+- <a name="recursive" href="#include_recursive">#</a> **recursive** (*true*):
+Lorsque cette option est désactivée, les fichiers inclus ne sont pas traités
+pour des inclusions récursives. Les valeurs possibles sont `true` et `false`.
 
 ##### Exemples
 

--- a/locale/fr/README.md.po
+++ b/locale/fr/README.md.po
@@ -402,6 +402,15 @@ msgid ""
 msgstr ""
 "[Globs génériques Bash]: https://facelessuser.github.io/wcmatch/glob/#syntax"
 
-#, fuzzy
 msgid "[pypi-link]: https://pypi.org/project/mkdocs-include-markdown-plugin"
 msgstr "[pypi-link]: https://pypi.org/project/mkdocs-include-markdown-plugin"
+
+msgid ""
+"<a name=\"recursive\" href=\"#include_recursive\">#</a> **recursive** "
+"(*true*): When this option is disabled, included files are not processed for"
+" recursive includes. Possible values are `true` and `false`."
+msgstr ""
+"<a name=\"recursive\" href=\"#include_recursive\">#</a> **recursive** "
+"(*true*): Lorsque cette option est désactivée, les fichiers inclus ne sont "
+"pas traités pour des inclusions récursives. Les valeurs possibles sont "
+"`true` et `false`."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-include-markdown-plugin"
-version = "6.0.6"
+version = "6.1.0"
 description = "Mkdocs Markdown includer plugin."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/mkdocs_include_markdown_plugin/config.py
+++ b/src/mkdocs_include_markdown_plugin/config.py
@@ -24,3 +24,4 @@ class PluginConfig(Config):  # noqa: D101
     end = Optional(MkType(str))
     exclude = ListOfItems(MkType(str), default=[])
     cache = MkType(int, default=0)
+    recursive = MkType(bool, default=True)

--- a/src/mkdocs_include_markdown_plugin/directive.py
+++ b/src/mkdocs_include_markdown_plugin/directive.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
             'comments': bool,
             'rewrite-relative-urls': bool,
             'heading-offset': int,
+            'recursive': bool,
             'start': str | None,
             'end': str | None,
         },
@@ -96,6 +97,7 @@ ARGUMENT_REGEXES = {
     'dedent': arg('dedent'),
     'trailing-newlines': arg('trailing-newlines'),
     'rewrite-relative-urls': arg('rewrite-relative-urls'),
+    'recursive': arg('recursive'),
 
     # int
     'heading-offset': arg('heading-offset'),

--- a/src/mkdocs_include_markdown_plugin/event.py
+++ b/src/mkdocs_include_markdown_plugin/event.py
@@ -608,12 +608,12 @@ def get_file_content(  # noqa: PLR0913, PLR0915
 
         return text_to_include
 
-    markdown = tags['include-markdown'].sub(
-        found_include_markdown_tag,
+    markdown = tags['include'].sub(
+        found_include_tag,
         markdown,
     )
-    return tags['include'].sub(
-        found_include_tag,
+    return tags['include-markdown'].sub(
+        found_include_markdown_tag,
         markdown,
     )
 

--- a/src/mkdocs_include_markdown_plugin/event.py
+++ b/src/mkdocs_include_markdown_plugin/event.py
@@ -165,7 +165,8 @@ def get_file_content(  # noqa: PLR0913, PLR0915
             files_watcher.included_files.extend(file_paths_to_include)
 
         bool_options, invalid_bool_args = parse_bool_options(
-            ['preserve-includer-indent', 'dedent', 'trailing-newlines'],
+            ['preserve-includer-indent', 'dedent',
+                'trailing-newlines', 'recursive'],
             defaults,
             arguments_string,
         )
@@ -248,16 +249,17 @@ def get_file_content(  # noqa: PLR0913, PLR0915
                         expected_but_any_found[i] = False
 
             # nested includes
-            new_text_to_include = get_file_content(
-                new_text_to_include,
-                file_path,
-                docs_dir,
-                tags,
-                defaults,
-                settings,
-                files_watcher=files_watcher,
-                http_cache=http_cache,
-            )
+            if bool_options['recursive'].value:
+                new_text_to_include = get_file_content(
+                    new_text_to_include,
+                    file_path,
+                    docs_dir,
+                    tags,
+                    defaults,
+                    settings,
+                    files_watcher=files_watcher,
+                    http_cache=http_cache,
+                )
 
             # trailing newlines right stripping
             if not bool_options['trailing-newlines'].value:
@@ -616,12 +618,12 @@ def get_file_content(  # noqa: PLR0913, PLR0915
 
         return text_to_include
 
-    markdown = tags['include'].sub(
-        found_include_tag,
+    markdown = tags['include-markdown'].sub(
+        found_include_markdown_tag,
         markdown,
     )
-    return tags['include-markdown'].sub(
-        found_include_markdown_tag,
+    return tags['include'].sub(
+        found_include_tag,
         markdown,
     )
 
@@ -651,6 +653,7 @@ def on_page_markdown(
             'comments': config.comments,
             'rewrite-relative-urls': config.rewrite_relative_urls,
             'heading-offset': config.heading_offset,
+            'recursive': config.recursive,
             'start': config.start,
             'end': config.end,
         },

--- a/tests/test_unit/test_nested_includes.py
+++ b/tests/test_unit/test_nested_includes.py
@@ -237,10 +237,8 @@ Included content
 %}''',
             '''# Header 2
 
-{%
-  include "{filepath}"
-  comments=false
-%}''',
+{% include "{filepath}" %}
+''',
             '''# Header 3
 
 This content must not be included.
@@ -249,10 +247,8 @@ This content must not be included.
 
 # Header 2
 
-{%
-  include "{filepath}"
-  comments=false
-%}''',
+{% include "{filepath}" %}
+''',
             [],
             id='include-recursive=false',
         ),

--- a/tests/test_unit/test_nested_includes.py
+++ b/tests/test_unit/test_nested_includes.py
@@ -226,6 +226,36 @@ Included content
             ],
             id='start-end-not-found (second-level)',
         ),
+        # recursive inclusion disabled with `include` directive
+        pytest.param(
+            '''# Header
+
+{%
+  include "{filepath}"
+  comments=false
+  recursive=false
+%}''',
+            '''# Header 2
+
+{%
+  include "{filepath}"
+  comments=false
+%}''',
+            '''# Header 3
+
+This content must not be included.
+''',
+            '''# Header
+
+# Header 2
+
+{%
+  include "{filepath}"
+  comments=false
+%}''',
+            [],
+            id='include-recursive=false',
+        ),
     ),
 )
 def test_nested_include(
@@ -247,6 +277,9 @@ def test_nested_include(
         '{filepath}', second_includer_file.as_posix(),
     )
     second_includer_content = second_includer_content.replace(
+        '{filepath}', included_file.as_posix(),
+    )
+    expected_result = expected_result.replace(
         '{filepath}', included_file.as_posix(),
     )
 


### PR DESCRIPTION
Fixes: #207

Additionally, it also excludes Jupyter Notebooks from the substitution, in case users are using `mkdocs-jupyter` to import files with very long text as cell outputs