### PR TITLE
Exclude mkdocs-gen-files from file watching when including them

### DIFF
--- a/src/mkdocs_include_markdown_plugin/plugin.py
+++ b/src/mkdocs_include_markdown_plugin/plugin.py
@@ -80,6 +80,8 @@ class IncludeMarkdownPlugin(BasePlugin[PluginConfig]):
 
         # watch new included files
         for file_path in watcher.included_files:
+            if 'mkdocs_gen_files_' in file_path:
+                continue
             server.watch(file_path, recursive=False)  # type: ignore
         watcher.included_files = []
 


### PR DESCRIPTION
Hi, thanks for the plugin!

I was going to create an issue but found a quick fix for an issue I'm having. It's just two lines of code, let me explain it:

This small change fixes an interaction between `include-markdown` and files generated from [`mkdocs-gen-files`](https://github.com/oprypin/mkdocs-gen-files). As the former adds blindly all included files to the `FileWatcher` (perfectly valid approach), this fails with dynamic files from mkdocs-gen-files, as they are written to a temporary directory that gets deleted shortly after.


### Example

It goes something like this (main points):

```python
import mkdocs_gen_files

with mkdocs_gen_files.open("project/examples/basic.py", "w") as virtual:
    virtual.write(Path("/path/to/true/basic.py").read_text()
```

And then on an examples documentation markdown:

```
{% include-markdown "project/examples/basic.py" %}
```

When running `mkdocs serve`, it'll fail with the error below:

```No such file or directory:  /tmp/mkdocs_gen_files_0xbb02fp/project/examples/basic.py```

### The fix

The traceback is quite long, but ultimately points to a `watchdog.observers` failing to find this file; bypassing `IncludeMarkdownPlugin._update_watched_files` fixes it, and as mkdocs-gen-files will always prefix to a directory starting with "[mkdocs_gen_files_](https://github.com/oprypin/mkdocs-gen-files/blob/7baa03225e6c34cc85d17f79c47e42eb2c2e359e/mkdocs_gen_files/plugin.py#L33)", simply filtering out those on your function does the trick and builds properly the website!

<hr>

I'll monkey patch to bypass this function in my code for now until a new release 🙂