### PR TITLE
Add HTML support for relative URL rewrites

### DIFF
--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -117,7 +117,18 @@ MARKDOWN_LINK_DEFINITION_REGEX = re.compile(
 MARKDOWN_HTML_IMAGE_REGEX = re.compile(
     r'''
         <img
-        \s+
+        [^>]*
+        src="(\S+?)"    # src = $1
+    ''',
+    flags=re.VERBOSE | re.MULTILINE,
+)
+
+# Match html source definition.
+# e.g. <img src="assets/diagram.png" alt="diagram" class="bar">
+MARKDOWN_HTML_SOURCE_REGEX = re.compile(
+    r'''
+        <source
+        [^>]*
         src="(\S+?)"    # src = $1
     ''',
     flags=re.VERBOSE | re.MULTILINE,
@@ -128,7 +139,7 @@ MARKDOWN_HTML_IMAGE_REGEX = re.compile(
 MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX = re.compile(
     r'''
         <a
-        \s+
+        [^>]*
         href="(\S+?)"    # href = $1
     ''',
     flags=re.VERBOSE | re.MULTILINE,
@@ -323,6 +334,10 @@ def rewrite_relative_urls(
             paragraph,
         )
         paragraph = MARKDOWN_HTML_IMAGE_REGEX.sub(
+            functools.partial(found_href, url_group_index=1),
+            paragraph,
+        )
+        paragraph = MARKDOWN_HTML_SOURCE_REGEX.sub(
             functools.partial(found_href, url_group_index=1),
             paragraph,
         )

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -290,10 +290,13 @@ def rewrite_relative_urls(
     from urllib.parse import urlparse, urlunparse
 
     def rewrite_url(url: str) -> str:
+        if is_url(url):
+            return url
+
         scheme, netloc, path, params, query, fragment = urlparse(url)
 
-        # external or absolute or mail
-        if (is_url(url) or path.startswith('/') or scheme == 'mailto'):
+        # absolute or mail
+        if path.startswith('/') or scheme == 'mailto':
             return url
 
         new_path = os.path.relpath(

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -347,11 +347,10 @@ def rewrite_relative_urls(
             functools.partial(found_href, url_group_index=1),
             paragraph,
         )
-        paragraph = MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX.sub(
+        return MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX.sub(
             functools.partial(found_href, url_group_index=1),
             paragraph,
         )
-        return paragraph
 
     return transform_p_by_p_skipping_codeblocks(
         markdown,

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -117,7 +117,17 @@ MARKDOWN_LINK_DEFINITION_REGEX = re.compile(
 MARKDOWN_HTML_IMAGE_REGEX = re.compile(
     r'''
         <img
-        [^>]*
+        (?:\s+             # More than one whitespace
+            (?!src=)       # Not src=
+            [\w-]+         # attribute name
+            \s*=\s*        # arbitrary whitespace
+            (?:
+                "[^"]*"    # Quoted value
+                |
+                '[^']*'    # Quoted value
+            )
+        )*                 # Other attributes are repeated 0 or more times
+        \s+                # More than one whitespace
         src="(\S+?)"    # src = $1
     ''',
     flags=re.VERBOSE | re.MULTILINE,
@@ -128,7 +138,17 @@ MARKDOWN_HTML_IMAGE_REGEX = re.compile(
 MARKDOWN_HTML_SOURCE_REGEX = re.compile(
     r'''
         <source
-        [^>]*
+        (?:\s+             # More than one whitespace
+            (?!src=)       # Not src=
+            [\w-]+         # attribute name
+            \s*=\s*        # arbitrary whitespace
+            (?:
+                "[^"]*"    # Quoted value
+                |
+                '[^']*'    # Quoted value
+            )
+        )*                 # Other attributes are repeated 0 or more times
+        \s+                # More than one whitespace
         src="(\S+?)"    # src = $1
     ''',
     flags=re.VERBOSE | re.MULTILINE,
@@ -139,7 +159,17 @@ MARKDOWN_HTML_SOURCE_REGEX = re.compile(
 MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX = re.compile(
     r'''
         <a
-        [^>]*
+        (?:\s+             # More than one whitespace
+            (?!src=)       # Not src=
+            [\w-]+         # attribute name
+            \s*=\s*        # arbitrary whitespace
+            (?:
+                "[^"]*"    # Quoted value
+                |
+                '[^']*'    # Quoted value
+            )
+        )*                 # Other attributes are repeated 0 or more times
+        \s+                # More than one whitespace
         href="(\S+?)"    # href = $1
     ''',
     flags=re.VERBOSE | re.MULTILINE,
@@ -282,8 +312,8 @@ def rewrite_relative_urls(
     def rewrite_url(url: str) -> str:
         scheme, netloc, path, params, query, fragment = urlparse(url)
 
-        # absolute or mail
-        if path.startswith('/') or scheme == 'mailto':
+        # external or absolute or mail
+        if (is_url(url) or path.startswith('/') or scheme == 'mailto'):
             return url
 
         new_path = os.path.relpath(

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -112,44 +112,24 @@ MARKDOWN_LINK_DEFINITION_REGEX = re.compile(
     flags=re.VERBOSE | re.MULTILINE,
 )
 
-# Matched html image definition.
+# Matched html image and source definition.
 # e.g. <img src="path/to/image.png" alt="alt-text">
+# e.g. <source src="path/to/image.png" alt="alt-text">
 MARKDOWN_HTML_IMAGE_REGEX = re.compile(
     r'''
-        <img
+        <(?:img|source)    # img or source
         (?:\s+             # More than one whitespace
             (?!src=)       # Not src=
             [\w-]+         # attribute name
-            \s*=\s*        # arbitrary whitespace
+            (?:\s*=\s*)?   # arbitrary whitespace (optional)
             (?:
-                "[^"]*"    # Quoted value
+                "[^"]*"    # Quoted value (double quote)
                 |
-                '[^']*'    # Quoted value
-            )
+                '[^']*'    # Quoted value (single quote)
+            )?
         )*                 # Other attributes are repeated 0 or more times
         \s+                # More than one whitespace
-        src="(\S+?)"    # src = $1
-    ''',
-    flags=re.VERBOSE | re.MULTILINE,
-)
-
-# Match html source definition.
-# e.g. <img src="assets/diagram.png" alt="diagram" class="bar">
-MARKDOWN_HTML_SOURCE_REGEX = re.compile(
-    r'''
-        <source
-        (?:\s+             # More than one whitespace
-            (?!src=)       # Not src=
-            [\w-]+         # attribute name
-            \s*=\s*        # arbitrary whitespace
-            (?:
-                "[^"]*"    # Quoted value
-                |
-                '[^']*'    # Quoted value
-            )
-        )*                 # Other attributes are repeated 0 or more times
-        \s+                # More than one whitespace
-        src="(\S+?)"    # src = $1
+        src=["'](\S+?)["'] # src = $1 (double quote or single quote)
     ''',
     flags=re.VERBOSE | re.MULTILINE,
 )
@@ -160,17 +140,17 @@ MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX = re.compile(
     r'''
         <a
         (?:\s+             # More than one whitespace
-            (?!src=)       # Not src=
+            (?!href=)      # Not href=
             [\w-]+         # attribute name
-            \s*=\s*        # arbitrary whitespace
+            (?:\s*=\s*)?   # arbitrary whitespace (optional)
             (?:
-                "[^"]*"    # Quoted value
+                "[^"]*"    # Quoted value (double quote)
                 |
-                '[^']*'    # Quoted value
-            )
+                '[^']*'    # Quoted value (single quote)
+            )?
         )*                 # Other attributes are repeated 0 or more times
         \s+                # More than one whitespace
-        href="(\S+?)"    # href = $1
+        href=["'](\S+?)["']# href = $1 (double quote or single quote)
     ''',
     flags=re.VERBOSE | re.MULTILINE,
 )
@@ -364,10 +344,6 @@ def rewrite_relative_urls(
             paragraph,
         )
         paragraph = MARKDOWN_HTML_IMAGE_REGEX.sub(
-            functools.partial(found_href, url_group_index=1),
-            paragraph,
-        )
-        paragraph = MARKDOWN_HTML_SOURCE_REGEX.sub(
             functools.partial(found_href, url_group_index=1),
             paragraph,
         )

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -112,6 +112,17 @@ MARKDOWN_LINK_DEFINITION_REGEX = re.compile(
     flags=re.VERBOSE | re.MULTILINE,
 )
 
+# Matched html image definition.
+# e.g. <img src="path/to/image.png" alt="alt-text">
+MARKDOWN_HTML_IMAGE_REGEX = re.compile(
+    r'''
+        <img
+        \s+
+        src="(\S+?)"    # src = $1
+    ''',
+    flags=re.VERBOSE | re.MULTILINE,
+)
+
 
 def transform_p_by_p_skipping_codeblocks(  # noqa: PLR0912, PLR0915
         markdown: str,
@@ -296,10 +307,15 @@ def rewrite_relative_urls(
             found_href_url_group_index_3,
             paragraph,
         )
-        return MARKDOWN_LINK_DEFINITION_REGEX.sub(
+        paragraph = MARKDOWN_LINK_DEFINITION_REGEX.sub(
             functools.partial(found_href, url_group_index=2),
             paragraph,
         )
+        paragraph = MARKDOWN_HTML_IMAGE_REGEX.sub(
+            functools.partial(found_href, url_group_index=1),
+            paragraph,
+        )
+        return paragraph
 
     return transform_p_by_p_skipping_codeblocks(
         markdown,

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -123,6 +123,17 @@ MARKDOWN_HTML_IMAGE_REGEX = re.compile(
     flags=re.VERBOSE | re.MULTILINE,
 )
 
+# Matched html anchor definition.
+# e.g. <a href="https://example.com">example</a>
+MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX = re.compile(
+    r'''
+        <a
+        \s+
+        href="(\S+?)"    # href = $1
+    ''',
+    flags=re.VERBOSE | re.MULTILINE,
+)
+
 
 def transform_p_by_p_skipping_codeblocks(  # noqa: PLR0912, PLR0915
         markdown: str,
@@ -312,6 +323,10 @@ def rewrite_relative_urls(
             paragraph,
         )
         paragraph = MARKDOWN_HTML_IMAGE_REGEX.sub(
+            functools.partial(found_href, url_group_index=1),
+            paragraph,
+        )
+        paragraph = MARKDOWN_HTML_ANCHOR_DEFINITION_REGEX.sub(
             functools.partial(found_href, url_group_index=1),
             paragraph,
         )

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -13,33 +13,13 @@ from mkdocs_include_markdown_plugin.process import (
 @pytest.mark.parametrize(
     ('markdown', 'source_path', 'destination_path', 'expected_result'),
     (
+        # Markdown Relative Links
         pytest.param(
             "Here's a [link](CHANGELOG.md) to the changelog.",
             'README',
             'docs/nav.md',
             "Here's a [link](../CHANGELOG.md) to the changelog.",
             id='relative-link',
-        ),
-        pytest.param(
-            "Here's a [link](/CHANGELOG.md) to the changelog.",
-            'README',
-            'docs/nav.md',
-            "Here's a [link](/CHANGELOG.md) to the changelog.",
-            id='absolute-link',
-        ),
-        pytest.param(
-            "Here's a [link](https://example.com/index.html) to the changelog.",
-            'README',
-            'docs/nav.md',
-            "Here's a [link](https://example.com/index.html) to the changelog.",
-            id='external-link',
-        ),
-        pytest.param(
-            "Here's a [link](https://example.com) to the changelog.",
-            'README',
-            'docs/nav.md',
-            "Here's a [link](https://example.com) to the changelog.",
-            id='external-top-level-link',
         ),
         pytest.param(
             '''Here's a [link whose text is really long and so is broken across
@@ -99,6 +79,7 @@ Check [this link](includes/feature_a/foobar.md) for more information
             'Build status: [![Build Status](../badge.png)](../build/)',
             id='image-inside-link',
         ),
+        # HTML Relative Links
         pytest.param(
             'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar" />',
             'README',
@@ -120,22 +101,36 @@ Check [this link](includes/feature_a/foobar.md) for more information
             'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',
             id='html-anchor',
         ),
-        # Adverarial tests: contains >, multiple tag in line.
         pytest.param(
-            '<img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',
+            "Here's a diagram: <img id='foo' src='assets/diagram.png' alt='diagram' class='bar' />",
             'README',
             'docs/home.md',
-            '<img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',
+            "Here's a diagram: <img id='foo' src='../assets/diagram.png' alt='diagram' class='bar' />",
+            id='html-image-single-quote',
+        ),
+        pytest.param(
+            "Here's a diagram: <a id='foo' href='assets/diagram.png' class='bar'>example</a>",
+            'README',
+            'docs/home.md',
+            "Here's a diagram: <a id='foo' href='../assets/diagram.png' class='bar'>example</a>",
+            id='html-anchor-single-quote',
+        ),
+        # HTML Relative Links Adverarial tests: attribute contains >, attribute without value, multiple tag in line.
+        pytest.param(
+            '<img id="foo" attr="3>2" attr2 src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',
+            'README',
+            'docs/home.md',
+            '<img id="foo" attr="3>2" attr2 src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',
             id='html-image-adverarial-test',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',
+            '<a id="foo" attr="3>2" attr2 href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',
+            '<a id="foo" attr="3>2" attr2 href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',
             id='html-anchor-adverarial-test',
         ),
-        # Adversarial test: img no end slash
+        # HTML Relative Links Adversarial test: img no end slash
         pytest.param(
             'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',
             'README',
@@ -143,7 +138,28 @@ Check [this link](includes/feature_a/foobar.md) for more information
             'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',
             id='html-image-no-end-slash',
         ),
-        # external link
+        # Non-relative links
+        pytest.param(
+            "Here's a [link](/CHANGELOG.md) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](/CHANGELOG.md) to the changelog.",
+            id='absolute-link',
+        ),
+        pytest.param(
+            "Here's a [link](https://example.com/index.html) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](https://example.com/index.html) to the changelog.",
+            id='external-link',
+        ),
+        pytest.param(
+            "Here's a [link](https://example.com) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](https://example.com) to the changelog.",
+            id='external-top-level-link',
+        ),
         pytest.param(
             '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',
             'README',

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -79,6 +79,13 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='image-inside-link',
         ),
         pytest.param(
+            'Here\'s a diagram: <img src="assets/diagram.png" alt="diagram">',
+            'README',
+            'docs/home.md',
+            'Here\'s a diagram: <img src="../assets/diagram.png" alt="diagram">',
+            id='html-image',
+        ),
+        pytest.param(
             '''[Homepage](/) [Github](https://github.com/user/repo)
 [Privacy policy](/privacy)''',
             'README',

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -81,61 +81,62 @@ Check [this link](includes/feature_a/foobar.md) for more information
         ),
         # HTML Relative Links
         pytest.param(
-            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar" />',
+            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar" />',
+            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
             id='html-image',
         ),
         pytest.param(
-            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar" />',
+            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar" />',
+            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar" />',  # noqa: E501
             id='html-source',
         ),
         pytest.param(
-            'Here\'s a diagram: <a id="foo" href="badge.png" class="bar">example</a>',
+            'Here\'s a diagram: <a id="foo" href="badge.png" class="bar">example</a>',  # noqa: E501
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',
+            'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',  # noqa: E501
             id='html-anchor',
         ),
         pytest.param(
-            "Here's a diagram: <img id='foo' src='assets/diagram.png' alt='diagram' class='bar' />",
+            "Here's a diagram: <img id='foo' src='assets/diagram.png' alt='diagram' class='bar' />",  # noqa: E501
             'README',
             'docs/home.md',
-            "Here's a diagram: <img id='foo' src='../assets/diagram.png' alt='diagram' class='bar' />",
+            "Here's a diagram: <img id='foo' src='../assets/diagram.png' alt='diagram' class='bar' />",  # noqa: E501
             id='html-image-single-quote',
         ),
         pytest.param(
-            "Here's a diagram: <a id='foo' href='assets/diagram.png' class='bar'>example</a>",
+            "Here's a diagram: <a id='foo' href='assets/diagram.png' class='bar'>example</a>",  # noqa: E501
             'README',
             'docs/home.md',
-            "Here's a diagram: <a id='foo' href='../assets/diagram.png' class='bar'>example</a>",
+            "Here's a diagram: <a id='foo' href='../assets/diagram.png' class='bar'>example</a>",  # noqa: E501
             id='html-anchor-single-quote',
         ),
-        # HTML Relative Links Adverarial tests: attribute contains >, attribute without value, multiple tag in line.
+        # HTML Relative Links Adverarial tests:
+        # (attribute contains >, attribute without value, multiple tag in line)
         pytest.param(
-            '<img id="foo" attr="3>2" attr2 src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',
+            '<img id="foo" attr="3>2" attr2 src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            '<img id="foo" attr="3>2" attr2 src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',
+            '<img id="foo" attr="3>2" attr2 src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
             id='html-image-adverarial-test',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" attr2 href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',
+            '<a id="foo" attr="3>2" attr2 href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',  # noqa: E501
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" attr2 href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',
+            '<a id="foo" attr="3>2" attr2 href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',  # noqa: E501
             id='html-anchor-adverarial-test',
         ),
         # HTML Relative Links Adversarial test: img no end slash
         pytest.param(
-            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',
+            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',  # noqa: E501
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',
+            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',  # noqa: E501
             id='html-image-no-end-slash',
         ),
         # Non-relative links
@@ -147,10 +148,10 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='absolute-link',
         ),
         pytest.param(
-            "Here's a [link](https://example.com/index.html) to the changelog.",
+            "Here's a [link](https://example.com/index.html) to the changelog.",  # noqa: E501
             'README',
             'docs/nav.md',
-            "Here's a [link](https://example.com/index.html) to the changelog.",
+            "Here's a [link](https://example.com/index.html) to the changelog.",  # noqa: E501
             id='external-link',
         ),
         pytest.param(
@@ -161,24 +162,24 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='external-top-level-link',
         ),
         pytest.param(
-            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',
+            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',
+            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',  # noqa: E501
             id='html-image-external-link',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',
+            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',
+            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',  # noqa: E501
             id='html-anchor-external-link',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',
+            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',  # noqa: E501
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',
+            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',  # noqa: E501
             id='html-anchor-external-top-level-link',
         ),
         pytest.param(

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -86,6 +86,13 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='html-image',
         ),
         pytest.param(
+            'Here\'s a diagram: <a href="badge.png">example</a>',
+            'README',
+            'docs/home.md',
+            'Here\'s a diagram: <a href="../badge.png">example</a>',
+            id='html-anchor',
+        ),
+        pytest.param(
             '''[Homepage](/) [Github](https://github.com/user/repo)
 [Privacy policy](/privacy)''',
             'README',
@@ -164,6 +171,21 @@ const auto lambda = []() { .... };
 ```
 ''',
             id='exclude-fenced-code-blocks',
+        ),
+        pytest.param(
+            '''```
+<img src="assets/diagram.png" alt="diagram">
+<a href="badge.png">example</a>
+```
+''',
+            'README',
+            'docs/nav.md',
+            '''```
+<img src="assets/diagram.png" alt="diagram">
+<a href="badge.png">example</a>
+```
+''',
+            id='exclude-fenced-code-blocks-html',
         ),
         pytest.param(
             (

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -81,62 +81,82 @@ Check [this link](includes/feature_a/foobar.md) for more information
         ),
         # HTML Relative Links
         pytest.param(
-            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
+            ('Here\'s a diagram: <img id="foo" src="assets/diagram.png"'
+             ' alt="diagram" class="bar" />'),
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
+            ('Here\'s a diagram: <img id="foo" src="../assets/diagram.png"'
+             ' alt="diagram" class="bar" />'),
             id='html-image',
         ),
         pytest.param(
-            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar" />',  # noqa: E501
+            ('Here\'s a diagram: <source id="foo" src="assets/diagram.png"'
+             ' class="bar" />'),
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar" />',  # noqa: E501
+            ('Here\'s a diagram: <source id="foo" src="../assets/diagram.png"'
+             ' class="bar" />'),
             id='html-source',
         ),
         pytest.param(
-            'Here\'s a diagram: <a id="foo" href="badge.png" class="bar">example</a>',  # noqa: E501
+            ('Here\'s a diagram: <a id="foo" href="badge.png"'
+             ' class="bar">example</a>'),
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',  # noqa: E501
+            ('Here\'s a diagram: <a id="foo" href="../badge.png"'
+             ' class="bar">example</a>'),
             id='html-anchor',
         ),
         pytest.param(
-            "Here's a diagram: <img id='foo' src='assets/diagram.png' alt='diagram' class='bar' />",  # noqa: E501
+            ("Here's a diagram: <img id='foo' src='assets/diagram.png'"
+             " alt='diagram' class='bar' />"),
             'README',
             'docs/home.md',
-            "Here's a diagram: <img id='foo' src='../assets/diagram.png' alt='diagram' class='bar' />",  # noqa: E501
+            ("Here's a diagram: <img id='foo' src='../assets/diagram.png'"
+             " alt='diagram' class='bar' />"),
             id='html-image-single-quote',
         ),
         pytest.param(
-            "Here's a diagram: <a id='foo' href='assets/diagram.png' class='bar'>example</a>",  # noqa: E501
+            ("Here's a diagram: <a id='foo' href='assets/diagram.png'"
+             " class='bar'>example</a>"),
             'README',
             'docs/home.md',
-            "Here's a diagram: <a id='foo' href='../assets/diagram.png' class='bar'>example</a>",  # noqa: E501
+            ("Here's a diagram: <a id='foo' href='../assets/diagram.png'"
+             " class='bar'>example</a>"),
             id='html-anchor-single-quote',
         ),
         # HTML Relative Links Adverarial tests:
         # (attribute contains >, attribute without value, multiple tag in line)
         pytest.param(
-            '<img id="foo" attr="3>2" attr2 src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
+            ('<img id="foo" attr="3>2" attr2 src="assets/diagram.png"'
+             ' alt="diagram" class="bar" /><img id="foo" attr="3>2"'
+             ' src="assets/diagram.png" alt="diagram" class="bar" />'),
             'README',
             'docs/home.md',
-            '<img id="foo" attr="3>2" attr2 src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',  # noqa: E501
+            ('<img id="foo" attr="3>2" attr2 src="../assets/diagram.png"'
+             ' alt="diagram" class="bar" /><img id="foo" attr="3>2"'
+             ' src="../assets/diagram.png" alt="diagram" class="bar" />'),
             id='html-image-adverarial-test',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" attr2 href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',  # noqa: E501
+            ('<a id="foo" attr="3>2" attr2 href="badge.png" class="bar">'
+             'foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">'
+             'bar</a>'),
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" attr2 href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',  # noqa: E501
+            ('<a id="foo" attr="3>2" attr2 href="../badge.png" class="bar">'
+             'foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">'
+             'bar</a>'),
             id='html-anchor-adverarial-test',
         ),
         # HTML Relative Links Adversarial test: img no end slash
         pytest.param(
-            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',  # noqa: E501
+            ('Here\'s a diagram: <img id="foo" src="assets/diagram.png"'
+             ' alt="diagram" class="bar">'),
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',  # noqa: E501
+            ('Here\'s a diagram: <img id="foo" src="../assets/diagram.png"'
+             ' alt="diagram" class="bar">'),
             id='html-image-no-end-slash',
         ),
         # Non-relative links
@@ -148,10 +168,10 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='absolute-link',
         ),
         pytest.param(
-            "Here's a [link](https://example.com/index.html) to the changelog.",  # noqa: E501
+            'A [link](https://example.com/index.html) to the changelog.',
             'README',
             'docs/nav.md',
-            "Here's a [link](https://example.com/index.html) to the changelog.",  # noqa: E501
+            'A [link](https://example.com/index.html) to the changelog.',
             id='external-link',
         ),
         pytest.param(
@@ -162,24 +182,28 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='external-top-level-link',
         ),
         pytest.param(
-            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',  # noqa: E501
+            ('<img id="foo" attr="3>2" src="https://example.com/image.png"'
+             ' class="bar" />'),
             'README',
             'docs/home.md',
-            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',  # noqa: E501
+            ('<img id="foo" attr="3>2" src="https://example.com/image.png"'
+             ' class="bar" />'),
             id='html-image-external-link',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',  # noqa: E501
+            ('<a id="foo" attr="3>2" href="https://example.com/index.html"'
+             ' class="bar" />'),
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',  # noqa: E501
+            ('<a id="foo" attr="3>2" href="https://example.com/index.html"'
+             ' class="bar" />'),
             id='html-anchor-external-link',
         ),
         pytest.param(
-            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',  # noqa: E501
+            '<a id="ab" attr="3>2" href="https://example.com" class="cd" />',
             'README',
             'docs/home.md',
-            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',  # noqa: E501
+            '<a id="ab" attr="3>2" href="https://example.com" class="cd" />',
             id='html-anchor-external-top-level-link',
         ),
         pytest.param(

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -79,17 +79,24 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='image-inside-link',
         ),
         pytest.param(
-            'Here\'s a diagram: <img src="assets/diagram.png" alt="diagram">',
+            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img src="../assets/diagram.png" alt="diagram">',
+            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',
             id='html-image',
         ),
         pytest.param(
-            'Here\'s a diagram: <a href="badge.png">example</a>',
+            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar">',
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <a href="../badge.png">example</a>',
+            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar">',
+            id='html-source',
+        ),
+        pytest.param(
+            'Here\'s a diagram: <a id="foo" href="badge.png" class="bar">example</a>',
+            'README',
+            'docs/home.md',
+            'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',
             id='html-anchor',
         ),
         pytest.param(

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -21,6 +21,27 @@ from mkdocs_include_markdown_plugin.process import (
             id='relative-link',
         ),
         pytest.param(
+            "Here's a [link](/CHANGELOG.md) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](/CHANGELOG.md) to the changelog.",
+            id='absolute-link',
+        ),
+        pytest.param(
+            "Here's a [link](https://example.com/index.html) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](https://example.com/index.html) to the changelog.",
+            id='external-link',
+        ),
+        pytest.param(
+            "Here's a [link](https://example.com) to the changelog.",
+            'README',
+            'docs/nav.md',
+            "Here's a [link](https://example.com) to the changelog.",
+            id='external-top-level-link',
+        ),
+        pytest.param(
             '''Here's a [link whose text is really long and so is broken across
 multiple lines](CHANGELOG.md) to the changelog.
 ''',
@@ -79,17 +100,17 @@ Check [this link](includes/feature_a/foobar.md) for more information
             id='image-inside-link',
         ),
         pytest.param(
-            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',
+            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar" />',
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',
+            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar" />',
             id='html-image',
         ),
         pytest.param(
-            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar">',
+            'Here\'s a diagram: <source id="foo" src="assets/diagram.png" class="bar" />',
             'README',
             'docs/home.md',
-            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar">',
+            'Here\'s a diagram: <source id="foo" src="../assets/diagram.png" class="bar" />',
             id='html-source',
         ),
         pytest.param(
@@ -98,6 +119,51 @@ Check [this link](includes/feature_a/foobar.md) for more information
             'docs/home.md',
             'Here\'s a diagram: <a id="foo" href="../badge.png" class="bar">example</a>',
             id='html-anchor',
+        ),
+        # Adverarial tests: contains >, multiple tag in line.
+        pytest.param(
+            '<img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="assets/diagram.png" alt="diagram" class="bar" />',
+            'README',
+            'docs/home.md',
+            '<img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" /><img id="foo" attr="3>2" src="../assets/diagram.png" alt="diagram" class="bar" />',
+            id='html-image-adverarial-test',
+        ),
+        pytest.param(
+            '<a id="foo" attr="3>2" href="badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="badge.png" class="bar">bar</a>',
+            'README',
+            'docs/home.md',
+            '<a id="foo" attr="3>2" href="../badge.png" class="bar">foo</a><a id="foo" attr="3>2" href="../badge.png" class="bar">bar</a>',
+            id='html-anchor-adverarial-test',
+        ),
+        # Adversarial test: img no end slash
+        pytest.param(
+            'Here\'s a diagram: <img id="foo" src="assets/diagram.png" alt="diagram" class="bar">',
+            'README',
+            'docs/home.md',
+            'Here\'s a diagram: <img id="foo" src="../assets/diagram.png" alt="diagram" class="bar">',
+            id='html-image-no-end-slash',
+        ),
+        # external link
+        pytest.param(
+            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',
+            'README',
+            'docs/home.md',
+            '<img id="foo" attr="3>2" src="https://example.com/image.png" class="bar" />',
+            id='html-image-external-link',
+        ),
+        pytest.param(
+            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',
+            'README',
+            'docs/home.md',
+            '<a id="foo" attr="3>2" href="https://example.com/index.html" class="bar" />',
+            id='html-anchor-external-link',
+        ),
+        pytest.param(
+            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',
+            'README',
+            'docs/home.md',
+            '<a id="foo" attr="3>2" href="https://example.com" class="bar" />',
+            id='html-anchor-external-top-level-link',
         ),
         pytest.param(
             '''[Homepage](/) [Github](https://github.com/user/repo)


### PR DESCRIPTION
**Description of Change**

- New Feature:
  - Add raw html (`image`, `source`, `a`) support for `rewrite_relative_url`.
- Fix:
  - Support external top level domain

**Checklist**

- [x] Feature working
- [x] Updated unit test

**Related Issue**

#251 