### PR TITLE
add remote markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,12 @@ content to include.
 
 ```jinja
 {%
+    include-markdown "https://myurl.com/folder1/folder2/file.md"
+%}
+```
+
+```jinja
+{%
     include-markdown "../README.md"
     start="<!--intro-start-->"
     end="<!--intro-end-->"

--- a/locale/es/README.md
+++ b/locale/es/README.md
@@ -229,6 +229,11 @@ especificado. Sólo soporta la sintaxis de encabezado de caracteres de hash
 (`#`). Acepta valores negativos para eliminar caracteres `#` a la izquierda.
 
 ##### Ejemplos
+```jinja
+{%
+    include-markdown "https://myurl.com/folder1/folder2/file.md"
+%}
+```
 
 ```jinja
 {%

--- a/locale/fr/README.md
+++ b/locale/fr/README.md
@@ -229,6 +229,11 @@ que la syntaxe d'en-tête du signe dièse (`#`). Cet argument accepte les valeur
 négatives pour supprimer les caractères `#` de tête.
 
 ##### Exemples
+```jinja
+{%
+    include-markdown "https://myurl.com/folder1/folder2/file.md"
+%}
+```
 
 ```jinja
 {%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-include-markdown-plugin"
-version = "7.2.1"
+version = "7.2.2"
 description = "Mkdocs Markdown includer plugin."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/mkdocs_include_markdown_plugin/process.py
+++ b/src/mkdocs_include_markdown_plugin/process.py
@@ -291,6 +291,10 @@ def rewrite_relative_urls(
     ``source_path`` will still work when inserted into a file at
     ``destination_path``.
     """
+
+    if re.search(r'^https?://', source_path): # if source_path is an URL, destination_path is not relevant
+        destination_path = ''
+
     def rewrite_url(url: str) -> str:
         if is_url(url) or is_absolute_path(url) or is_anchor(url):
             return url
@@ -302,6 +306,8 @@ def rewrite_relative_urls(
 
         # ensure forward slashes are used, on Windows
         new_path = new_path.replace('\\', '/').replace('//', '/')
+        new_path = re.sub(r'^http:/', 'http://', new_path)  # fix new_path if the source is an URL
+        new_path = re.sub(r'^https:/', 'https://', new_path) # fix new_path if the source is an URL
 
         try:
             if url[-1] == '/':

--- a/tests/test_unit/test_process.py
+++ b/tests/test_unit/test_process.py
@@ -15,6 +15,20 @@ from mkdocs_include_markdown_plugin.process import (
     (
         # Markdown Relative Links
         pytest.param(
+            "Here's an image: ![link1](../vector.drawio.svg) and another image ![link2](../../image.png) to the changelog.",
+            'http://example.com/folder1/folder2/folder3/README.md',
+            'docs/nav.md',
+            "Here's an image: ![link1](http://example.com/folder1/folder2/vector.drawio.svg) and another image ![link2](http://example.com/folder1/image.png) to the changelog.",
+            id='relative-link',
+        ),
+        pytest.param(
+            "Here's an image: ![link1](../vector.drawio.svg) and another image ![link2](../../image.png) to the changelog.",
+            'https://example.com/folder1/folder2/folder3/README.md',
+            'docs/nav.md',
+            "Here's an image: ![link1](https://example.com/folder1/folder2/vector.drawio.svg) and another image ![link2](https://example.com/folder1/image.png) to the changelog.",
+            id='relative-link',
+        ),
+        pytest.param(
             "Here's a [link](CHANGELOG.md) to the changelog.",
             'README',
             'docs/nav.md',


### PR DESCRIPTION
# Remote Markdown Inclusion

This PR enables including markdown files from remote repositories (e.g. GitHub).
This allows you to embed common guidelines defined in a central repository into multiple MkDocs projects.

## Usage

```markdown
{%
    include-markdown "https://myurl.com/folder1/folder2/file.md"
%}
```

Relative links in the remote markdown file will be corrected automatically.